### PR TITLE
Add context limit support for MCP compatibility - [Add Context Limit Support for MCP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ A Model Context Protocol (MCP) server implementation that integrates with [Firec
 - Automatic retries and rate limiting
 - Cloud and self-hosted support
 - SSE support
+- **Context limit support for MCP compatibility**
+
+## Context Limiting for MCP
+
+All tools now support the `maxResponseSize` parameter to limit response size for better MCP compatibility. This is especially useful for large responses that may exceed MCP context limits.
+
+**Example Usage:**
+```json
+{
+  "name": "firecrawl_scrape",
+  "arguments": {
+    "url": "https://example.com",
+    "formats": ["markdown"],
+    "maxResponseSize": 50000
+  }
+}
+```
+
+When the response exceeds the specified limit, content will be truncated with a clear message indicating truncation occurred. This parameter is optional and preserves full backward compatibility.
 
 > Play around with [our MCP Server on MCP.so's playground](https://mcp.so/playground?server=firecrawl-mcp-server) or on [Klavis AI](https://www.klavis.ai/mcp-servers).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.1.9",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firecrawl-mcp",
-      "version": "3.1.9",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@mendable/firecrawl-js": "^4.3.4",
         "dotenv": "^17.2.2",
         "firecrawl-fastmcp": "^1.0.2",
+        "node-fetch": "^2.7.0",
         "typescript": "^5.9.2",
         "zod": "^4.1.5"
       },
@@ -1223,6 +1224,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -1732,6 +1753,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1839,6 +1866,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mendable/firecrawl-js": "^4.3.4",
     "dotenv": "^17.2.2",
     "firecrawl-fastmcp": "^1.0.2",
+    "node-fetch": "^2.7.0",
     "typescript": "^5.9.2",
     "zod": "^4.1.5"
   },


### PR DESCRIPTION
# Add Context Limit Support for MCP Compatibility

## Summary
Adds `maxResponseSize` parameter to all MCP tools to limit response size for better MCP compatibility.

## Changes
- Added optional `maxResponseSize` parameter to all tools (scrape, map, search, crawl, check_crawl_status, extract)
- Enhanced `asText()` function with intelligent truncation
- Added clear truncation message when limit exceeded
- Updated tool descriptions and README documentation

<img width="1920" height="1200" alt="Screenshot from 2025-09-17 15-15-29" src="https://github.com/user-attachments/assets/4a716446-b2ca-4846-b4f4-1cd8dc0bc6ef" />


## Usage
```json
{
  "name": "firecrawl_scrape",
  "arguments": {
    "url": "https://example.com",
    "maxResponseSize": 2000
  }
}
```

## Benefits
- Prevents MCP context overflow issues
- Fully backward compatible (parameter is optional)
- Works with all existing integrations
- Clear user feedback when truncation occurs

## Testing
✅ Tested with Claude Desktop - truncation works correctly
✅ Backward compatibility confirmed
✅ All tools support the new parameter

Fixes https://github.com/firecrawl/firecrawl/issues/2165