### PR TITLE
docs: add GitHub Copilot CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,40 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
+### Usage with GitHub Copilot CLI
+
+Use the Copilot CLI to interactively add the MCP server:
+
+```bash
+/mcp add
+```
+
+Alternatively, create or edit `~/.copilot/mcp-config.json` and add:
+
+```json
+{
+  "mcpServers": {
+    "firecrawl-mcp": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE",
+
+        "FIRECRAWL_RETRY_MAX_ATTEMPTS": "5",
+        "FIRECRAWL_RETRY_INITIAL_DELAY": "2000",
+        "FIRECRAWL_RETRY_MAX_DELAY": "30000",
+        "FIRECRAWL_RETRY_BACKOFF_FACTOR": "3",
+
+        "FIRECRAWL_CREDIT_WARNING_THRESHOLD": "2000",
+        "FIRECRAWL_CREDIT_CRITICAL_THRESHOLD": "500"
+      }
+    }
+  }
+}
+```
+
+For more information, see the [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+
 ### System Configuration
 
 The server includes several configurable parameters that can be set via environment variables. Here are the default values if not configured:


### PR DESCRIPTION
Adds GitHub Copilot CLI setup instructions to the README, following the same pattern as the existing Claude Desktop section.

## Changes
- Added "Usage with GitHub Copilot CLI" section after Claude Desktop
- Includes interactive setup (`/mcp add`) and manual JSON configuration
- Matches existing env var pattern (API key + retry + credit monitoring)
- Links to official Copilot CLI documentation