### PR TITLE
feat: Add MCP protocol regression tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,56 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: pnpm
+
+      - name: Install mcp-recorder
+        run: pip install -r integration/requirements.txt
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Start MCP server
+        run: FIRECRAWL_API_KEY=test HTTP_STREAMABLE_SERVER=true node dist/index.js &
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 10); do
+            curl -sf http://localhost:3000/health && exit 0
+            sleep 1
+          done
+          echo "Server failed to start" && exit 1
+
+      - name: Verify protocol cassette
+        run: |
+          mcp-recorder verify \
+            --cassette integration/cassettes/protocol_and_errors.json \
+            --target http://localhost:3000 \
+            --verbose

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,56 @@
+# Integration Tests
+
+Snapshot-based regression tests for the MCP protocol surface. A golden cassette records the `initialize` handshake, all tool schemas via `tools/list`, and error handling. CI verifies that every PR still matches. If a tool is renamed, removed, or has its schema changed, the diff shows exactly what broke.
+
+Uses [mcp-recorder](https://github.com/devhelmhq/mcp-recorder) for recording and verification.
+
+## What's tested
+
+| Cassette | What it guards |
+|---|---|
+| `protocol_and_errors.json` | Protocol version, capabilities, all tool schemas, error responses |
+
+## Setup
+
+```bash
+pip install -r integration/requirements.txt
+```
+
+## Verify locally
+
+```bash
+pnpm build
+FIRECRAWL_API_KEY=test HTTP_STREAMABLE_SERVER=true node dist/index.js &
+
+mcp-recorder verify \
+  --cassette integration/cassettes/protocol_and_errors.json \
+  --target http://localhost:3000 \
+  --verbose
+```
+
+All 4 interactions should pass. Kill the server when done.
+
+## Update cassettes after intentional changes
+
+When you've changed a tool schema or added a new tool, update the cassette with one command:
+
+```bash
+# Start the server, then:
+mcp-recorder verify \
+  --cassette integration/cassettes/protocol_and_errors.json \
+  --target http://localhost:3000 \
+  --update
+```
+
+This replays the recorded requests, accepts the new responses, and writes them back to the cassette. Commit the updated cassette with your PR — the diff makes the schema change visible in review.
+
+## Add new test scenarios
+
+Edit `scenarios.yml` and re-record:
+
+```bash
+mcp-recorder record-scenarios integration/scenarios.yml \
+  --output-dir integration/cassettes
+```
+
+See the [mcp-recorder docs](https://github.com/devhelmhq/mcp-recorder) for supported actions.

--- a/integration/cassettes/protocol_and_errors.json
+++ b/integration/cassettes/protocol_and_errors.json
@@ -1,0 +1,1220 @@
+{
+  "version": "1.0",
+  "metadata": {
+    "recorded_at": "2026-03-01T21:07:43.288185+00:00",
+    "server_url": "http://localhost:3000",
+    "protocol_version": "2025-06-18",
+    "server_info": {
+      "name": "firecrawl-fastmcp",
+      "version": "3.0.0"
+    }
+  },
+  "interactions": [
+    {
+      "type": "jsonrpc_request",
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+          "protocolVersion": "2025-11-25",
+          "capabilities": {},
+          "clientInfo": {
+            "name": "mcp-recorder",
+            "version": "0.1.0"
+          }
+        }
+      },
+      "response": {
+        "result": {
+          "protocolVersion": "2025-06-18",
+          "capabilities": {
+            "tools": {},
+            "logging": {}
+          },
+          "serverInfo": {
+            "name": "firecrawl-fastmcp",
+            "version": "3.0.0"
+          }
+        },
+        "jsonrpc": "2.0",
+        "id": 0
+      },
+      "response_is_sse": true,
+      "response_status": 200,
+      "latency_ms": 16,
+      "http_method": null,
+      "http_path": null
+    },
+    {
+      "type": "notification",
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+      },
+      "response": null,
+      "response_is_sse": false,
+      "response_status": 202,
+      "latency_ms": 2,
+      "http_method": null,
+      "http_path": null
+    },
+    {
+      "type": "jsonrpc_request",
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+      },
+      "response": {
+        "result": {
+          "tools": [
+            {
+              "description": "\nScrape content from a single URL with advanced options.\nThis is the most powerful, fastest and most reliable scraper tool, if available you should always default to using this tool for any web scraping needs.\n\n**Best for:** Single page content extraction, when you know exactly which page contains the information.\n**Not recommended for:** Multiple pages (call scrape multiple times or use crawl), unknown page location (use search).\n**Common mistakes:** Using markdown format when extracting specific data points (use JSON instead).\n**Other Features:** Use 'branding' format to extract brand identity (colors, fonts, typography, spacing, UI components) for design analysis or style replication.\n\n**CRITICAL - Format Selection (you MUST follow this):**\nWhen the user asks for SPECIFIC data points, you MUST use JSON format with a schema. Only use markdown when the user needs the ENTIRE page content.\n\n**Use JSON format when user asks for:**\n- Parameters, fields, or specifications (e.g., \"get the header parameters\", \"what are the required fields\")\n- Prices, numbers, or structured data (e.g., \"extract the pricing\", \"get the product details\")\n- API details, endpoints, or technical specs (e.g., \"find the authentication endpoint\")\n- Lists of items or properties (e.g., \"list the features\", \"get all the options\")\n- Any specific piece of information from a page\n\n**Use markdown format ONLY when:**\n- User wants to read/summarize an entire article or blog post\n- User needs to see all content on a page without specific extraction\n- User explicitly asks for the full page content\n\n**Handling JavaScript-rendered pages (SPAs):**\nIf JSON extraction returns empty, minimal, or just navigation content, the page is likely JavaScript-rendered or the content is on a different URL. Try these steps IN ORDER:\n1. **Add waitFor parameter:** Set `waitFor: 5000` to `waitFor: 10000` to allow JavaScript to render before extraction\n2. **Try a different URL:** If the URL has a hash fragment (#section), try the base URL or look for a direct page URL\n3. **Use firecrawl_map to find the correct page:** Large documentation sites or SPAs often spread content across multiple URLs. Use `firecrawl_map` with a `search` parameter to discover the specific page containing your target content, then scrape that URL directly.\n   Example: If scraping \"https://docs.example.com/reference\" fails to find webhook parameters, use `firecrawl_map` with `{\"url\": \"https://docs.example.com/reference\", \"search\": \"webhook\"}` to find URLs like \"/reference/webhook-events\", then scrape that specific page.\n4. **Use firecrawl_agent:** As a last resort for heavily dynamic pages where map+scrape still fails, use the agent which can autonomously navigate and research\n\n**Usage Example (JSON format - REQUIRED for specific data extraction):**\n```json\n{\n  \"name\": \"firecrawl_scrape\",\n  \"arguments\": {\n    \"url\": \"https://example.com/api-docs\",\n    \"formats\": [{\n      \"type\": \"json\",\n      \"prompt\": \"Extract the header parameters for the authentication endpoint\",\n      \"schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"parameters\": {\n            \"type\": \"array\",\n            \"items\": {\n              \"type\": \"object\",\n              \"properties\": {\n                \"name\": { \"type\": \"string\" },\n                \"type\": { \"type\": \"string\" },\n                \"required\": { \"type\": \"boolean\" },\n                \"description\": { \"type\": \"string\" }\n              }\n            }\n          }\n        }\n      }\n    }]\n  }\n}\n```\n**Usage Example (markdown format - ONLY when full content genuinely needed):**\n```json\n{\n  \"name\": \"firecrawl_scrape\",\n  \"arguments\": {\n    \"url\": \"https://example.com/article\",\n    \"formats\": [\"markdown\"],\n    \"onlyMainContent\": true\n  }\n}\n```\n**Usage Example (branding format - extract brand identity):**\n```json\n{\n  \"name\": \"firecrawl_scrape\",\n  \"arguments\": {\n    \"url\": \"https://example.com\",\n    \"formats\": [\"branding\"]\n  }\n}\n```\n**Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.\n**Performance:** Add maxAge parameter for 500% faster scrapes using cached data.\n**Returns:** JSON structured data, markdown, branding profile, or other formats as specified.\n\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "formats": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "markdown",
+                            "html",
+                            "rawHtml",
+                            "screenshot",
+                            "links",
+                            "summary",
+                            "changeTracking",
+                            "branding"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "json"
+                            },
+                            "prompt": {
+                              "type": "string"
+                            },
+                            "schema": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              },
+                              "additionalProperties": {}
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "const": "screenshot"
+                            },
+                            "fullPage": {
+                              "type": "boolean"
+                            },
+                            "quality": {
+                              "type": "number"
+                            },
+                            "viewport": {
+                              "type": "object",
+                              "properties": {
+                                "width": {
+                                  "type": "number"
+                                },
+                                "height": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "width",
+                                "height"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "parsers": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "pdf"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "pdf"
+                              ]
+                            },
+                            "maxPages": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 10000
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "onlyMainContent": {
+                    "type": "boolean"
+                  },
+                  "includeTags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "excludeTags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "waitFor": {
+                    "type": "number"
+                  },
+                  "actions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "wait",
+                            "screenshot",
+                            "scroll",
+                            "scrape",
+                            "click",
+                            "write",
+                            "press",
+                            "executeJavascript",
+                            "generatePDF"
+                          ]
+                        },
+                        "selector": {
+                          "type": "string"
+                        },
+                        "milliseconds": {
+                          "type": "number"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "up",
+                            "down"
+                          ]
+                        },
+                        "script": {
+                          "type": "string"
+                        },
+                        "fullPage": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "mobile": {
+                    "type": "boolean"
+                  },
+                  "skipTlsVerification": {
+                    "type": "boolean"
+                  },
+                  "removeBase64Images": {
+                    "type": "boolean"
+                  },
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "country": {
+                        "type": "string"
+                      },
+                      "languages": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "storeInCache": {
+                    "type": "boolean"
+                  },
+                  "zeroDataRetention": {
+                    "type": "boolean"
+                  },
+                  "maxAge": {
+                    "type": "number"
+                  },
+                  "proxy": {
+                    "type": "string",
+                    "enum": [
+                      "basic",
+                      "stealth",
+                      "enhanced",
+                      "auto"
+                    ]
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_scrape"
+            },
+            {
+              "description": "\nMap a website to discover all indexed URLs on the site.\n\n**Best for:** Discovering URLs on a website before deciding what to scrape; finding specific sections or pages within a large site; locating the correct page when scrape returns empty or incomplete results.\n**Not recommended for:** When you already know which specific URL you need (use scrape); when you need the content of the pages (use scrape after mapping).\n**Common mistakes:** Using crawl to discover URLs instead of map; jumping straight to firecrawl_agent when scrape fails instead of using map first to find the right page.\n\n**IMPORTANT - Use map before agent:** If `firecrawl_scrape` returns empty, minimal, or irrelevant content, use `firecrawl_map` with the `search` parameter to find the specific page URL containing your target content. This is faster and cheaper than using `firecrawl_agent`. Only use the agent as a last resort after map+scrape fails.\n\n**Prompt Example:** \"Find the webhook documentation page on this API docs site.\"\n**Usage Example (discover all URLs):**\n```json\n{\n  \"name\": \"firecrawl_map\",\n  \"arguments\": {\n    \"url\": \"https://example.com\"\n  }\n}\n```\n**Usage Example (search for specific content - RECOMMENDED when scrape fails):**\n```json\n{\n  \"name\": \"firecrawl_map\",\n  \"arguments\": {\n    \"url\": \"https://docs.example.com/api\",\n    \"search\": \"webhook events\"\n  }\n}\n```\n**Returns:** Array of URLs found on the site, filtered by search query if provided.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "search": {
+                    "type": "string"
+                  },
+                  "sitemap": {
+                    "type": "string",
+                    "enum": [
+                      "include",
+                      "skip",
+                      "only"
+                    ]
+                  },
+                  "includeSubdomains": {
+                    "type": "boolean"
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "ignoreQueryParameters": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_map"
+            },
+            {
+              "description": "\nSearch the web and optionally extract content from search results. This is the most powerful web search tool available, and if available you should always default to using this tool for any web search needs.\n\nThe query also supports search operators, that you can use if needed to refine the search:\n| Operator | Functionality | Examples |\n---|-|-|\n| `\"\"` | Non-fuzzy matches a string of text | `\"Firecrawl\"`\n| `-` | Excludes certain keywords or negates other operators | `-bad`, `-site:firecrawl.dev`\n| `site:` | Only returns results from a specified website | `site:firecrawl.dev`\n| `inurl:` | Only returns results that include a word in the URL | `inurl:firecrawl`\n| `allinurl:` | Only returns results that include multiple words in the URL | `allinurl:git firecrawl`\n| `intitle:` | Only returns results that include a word in the title of the page | `intitle:Firecrawl`\n| `allintitle:` | Only returns results that include multiple words in the title of the page | `allintitle:firecrawl playground`\n| `related:` | Only returns results that are related to a specific domain | `related:firecrawl.dev`\n| `imagesize:` | Only returns images with exact dimensions | `imagesize:1920x1080`\n| `larger:` | Only returns images larger than specified dimensions | `larger:1920x1080`\n\n**Best for:** Finding specific information across multiple websites, when you don't know which website has the information; when you need the most relevant content for a query.\n**Not recommended for:** When you need to search the filesystem. When you already know which website to scrape (use scrape); when you need comprehensive coverage of a single website (use map or crawl.\n**Common mistakes:** Using crawl or map for open-ended questions (use search instead).\n**Prompt Example:** \"Find the latest research papers on AI published in 2023.\"\n**Sources:** web, images, news, default to web unless needed images or news.\n**Scrape Options:** Only use scrapeOptions when you think it is absolutely necessary. When you do so default to a lower limit to avoid timeouts, 5 or lower.\n**Optimal Workflow:** Search first using firecrawl_search without formats, then after fetching the results, use the scrape tool to get the content of the relevantpage(s) that you want to scrape\n\n**Usage Example without formats (Preferred):**\n```json\n{\n  \"name\": \"firecrawl_search\",\n  \"arguments\": {\n    \"query\": \"top AI companies\",\n    \"limit\": 5,\n    \"sources\": [\n      { \"type\": \"web\" }\n    ]\n  }\n}\n```\n**Usage Example with formats:**\n```json\n{\n  \"name\": \"firecrawl_search\",\n  \"arguments\": {\n    \"query\": \"latest AI research papers 2023\",\n    \"limit\": 5,\n    \"lang\": \"en\",\n    \"country\": \"us\",\n    \"sources\": [\n      { \"type\": \"web\" },\n      { \"type\": \"images\" },\n      { \"type\": \"news\" }\n    ],\n    \"scrapeOptions\": {\n      \"formats\": [\"markdown\"],\n      \"onlyMainContent\": true\n    }\n  }\n}\n```\n**Returns:** Array of search results (with optional scraped content).\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "tbs": {
+                    "type": "string"
+                  },
+                  "filter": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "sources": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "web",
+                            "images",
+                            "news"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "scrapeOptions": {
+                    "type": "object",
+                    "properties": {
+                      "formats": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "markdown",
+                                "html",
+                                "rawHtml",
+                                "screenshot",
+                                "links",
+                                "summary",
+                                "changeTracking",
+                                "branding"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "const": "json"
+                                },
+                                "prompt": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "type": "object",
+                                  "propertyNames": {
+                                    "type": "string"
+                                  },
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "const": "screenshot"
+                                },
+                                "fullPage": {
+                                  "type": "boolean"
+                                },
+                                "quality": {
+                                  "type": "number"
+                                },
+                                "viewport": {
+                                  "type": "object",
+                                  "properties": {
+                                    "width": {
+                                      "type": "number"
+                                    },
+                                    "height": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "width",
+                                    "height"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "parsers": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "pdf"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "pdf"
+                                  ]
+                                },
+                                "maxPages": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 10000
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "onlyMainContent": {
+                        "type": "boolean"
+                      },
+                      "includeTags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "excludeTags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "waitFor": {
+                        "type": "number"
+                      },
+                      "actions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "wait",
+                                "screenshot",
+                                "scroll",
+                                "scrape",
+                                "click",
+                                "write",
+                                "press",
+                                "executeJavascript",
+                                "generatePDF"
+                              ]
+                            },
+                            "selector": {
+                              "type": "string"
+                            },
+                            "milliseconds": {
+                              "type": "number"
+                            },
+                            "text": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "up",
+                                "down"
+                              ]
+                            },
+                            "script": {
+                              "type": "string"
+                            },
+                            "fullPage": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "mobile": {
+                        "type": "boolean"
+                      },
+                      "skipTlsVerification": {
+                        "type": "boolean"
+                      },
+                      "removeBase64Images": {
+                        "type": "boolean"
+                      },
+                      "location": {
+                        "type": "object",
+                        "properties": {
+                          "country": {
+                            "type": "string"
+                          },
+                          "languages": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "storeInCache": {
+                        "type": "boolean"
+                      },
+                      "zeroDataRetention": {
+                        "type": "boolean"
+                      },
+                      "maxAge": {
+                        "type": "number"
+                      },
+                      "proxy": {
+                        "type": "string",
+                        "enum": [
+                          "basic",
+                          "stealth",
+                          "enhanced",
+                          "auto"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "enterprise": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "default",
+                        "anon",
+                        "zdr"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_search"
+            },
+            {
+              "description": "\n Starts a crawl job on a website and extracts content from all pages.\n \n **Best for:** Extracting content from multiple related pages, when you need comprehensive coverage.\n **Not recommended for:** Extracting content from a single page (use scrape); when token limits are a concern (use map + batch_scrape); when you need fast results (crawling can be slow).\n **Warning:** Crawl responses can be very large and may exceed token limits. Limit the crawl depth and number of pages, or use map + batch_scrape for better control.\n **Common mistakes:** Setting limit or maxDiscoveryDepth too high (causes token overflow) or too low (causes missing pages); using crawl for a single page (use scrape instead). Using a /* wildcard is not recommended.\n **Prompt Example:** \"Get all blog posts from the first two levels of example.com/blog.\"\n **Usage Example:**\n ```json\n {\n   \"name\": \"firecrawl_crawl\",\n   \"arguments\": {\n     \"url\": \"https://example.com/blog/*\",\n     \"maxDiscoveryDepth\": 5,\n     \"limit\": 20,\n     \"allowExternalLinks\": false,\n     \"deduplicateSimilarURLs\": true,\n     \"sitemap\": \"include\"\n   }\n }\n ```\n **Returns:** Operation ID for status checking; use firecrawl_check_crawl_status to check progress.\n \n ",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  },
+                  "excludePaths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "includePaths": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "maxDiscoveryDepth": {
+                    "type": "number"
+                  },
+                  "sitemap": {
+                    "type": "string",
+                    "enum": [
+                      "skip",
+                      "include",
+                      "only"
+                    ]
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "allowExternalLinks": {
+                    "type": "boolean"
+                  },
+                  "allowSubdomains": {
+                    "type": "boolean"
+                  },
+                  "crawlEntireDomain": {
+                    "type": "boolean"
+                  },
+                  "delay": {
+                    "type": "number"
+                  },
+                  "maxConcurrency": {
+                    "type": "number"
+                  },
+                  "webhook": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "headers": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            },
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "deduplicateSimilarURLs": {
+                    "type": "boolean"
+                  },
+                  "ignoreQueryParameters": {
+                    "type": "boolean"
+                  },
+                  "scrapeOptions": {
+                    "type": "object",
+                    "properties": {
+                      "formats": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "markdown",
+                                "html",
+                                "rawHtml",
+                                "screenshot",
+                                "links",
+                                "summary",
+                                "changeTracking",
+                                "branding"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "const": "json"
+                                },
+                                "prompt": {
+                                  "type": "string"
+                                },
+                                "schema": {
+                                  "type": "object",
+                                  "propertyNames": {
+                                    "type": "string"
+                                  },
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "const": "screenshot"
+                                },
+                                "fullPage": {
+                                  "type": "boolean"
+                                },
+                                "quality": {
+                                  "type": "number"
+                                },
+                                "viewport": {
+                                  "type": "object",
+                                  "properties": {
+                                    "width": {
+                                      "type": "number"
+                                    },
+                                    "height": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "width",
+                                    "height"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "parsers": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "pdf"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "pdf"
+                                  ]
+                                },
+                                "maxPages": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 10000
+                                }
+                              },
+                              "required": [
+                                "type"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "onlyMainContent": {
+                        "type": "boolean"
+                      },
+                      "includeTags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "excludeTags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "waitFor": {
+                        "type": "number"
+                      },
+                      "actions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "wait",
+                                "screenshot",
+                                "scroll",
+                                "scrape",
+                                "click",
+                                "write",
+                                "press",
+                                "executeJavascript",
+                                "generatePDF"
+                              ]
+                            },
+                            "selector": {
+                              "type": "string"
+                            },
+                            "milliseconds": {
+                              "type": "number"
+                            },
+                            "text": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "up",
+                                "down"
+                              ]
+                            },
+                            "script": {
+                              "type": "string"
+                            },
+                            "fullPage": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "mobile": {
+                        "type": "boolean"
+                      },
+                      "skipTlsVerification": {
+                        "type": "boolean"
+                      },
+                      "removeBase64Images": {
+                        "type": "boolean"
+                      },
+                      "location": {
+                        "type": "object",
+                        "properties": {
+                          "country": {
+                            "type": "string"
+                          },
+                          "languages": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "storeInCache": {
+                        "type": "boolean"
+                      },
+                      "zeroDataRetention": {
+                        "type": "boolean"
+                      },
+                      "maxAge": {
+                        "type": "number"
+                      },
+                      "proxy": {
+                        "type": "string",
+                        "enum": [
+                          "basic",
+                          "stealth",
+                          "enhanced",
+                          "auto"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_crawl"
+            },
+            {
+              "description": "\nCheck the status of a crawl job.\n\n**Usage Example:**\n```json\n{\n  \"name\": \"firecrawl_check_crawl_status\",\n  \"arguments\": {\n    \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n}\n```\n**Returns:** Status and progress of the crawl job, including results if available.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_check_crawl_status"
+            },
+            {
+              "description": "\nExtract structured information from web pages using LLM capabilities. Supports both cloud AI and self-hosted LLM extraction.\n\n**Best for:** Extracting specific structured data like prices, names, details from web pages.\n**Not recommended for:** When you need the full content of a page (use scrape); when you're not looking for specific structured data.\n**Arguments:**\n- urls: Array of URLs to extract information from\n- prompt: Custom prompt for the LLM extraction\n- schema: JSON schema for structured data extraction\n- allowExternalLinks: Allow extraction from external links\n- enableWebSearch: Enable web search for additional context\n- includeSubdomains: Include subdomains in extraction\n**Prompt Example:** \"Extract the product name, price, and description from these product pages.\"\n**Usage Example:**\n```json\n{\n  \"name\": \"firecrawl_extract\",\n  \"arguments\": {\n    \"urls\": [\"https://example.com/page1\", \"https://example.com/page2\"],\n    \"prompt\": \"Extract product information including name, price, and description\",\n    \"schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"name\": { \"type\": \"string\" },\n        \"price\": { \"type\": \"number\" },\n        \"description\": { \"type\": \"string\" }\n      },\n      \"required\": [\"name\", \"price\"]\n    },\n    \"allowExternalLinks\": false,\n    \"enableWebSearch\": false,\n    \"includeSubdomains\": false\n  }\n}\n```\n**Returns:** Extracted structured data as defined by your schema.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "urls": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "prompt": {
+                    "type": "string"
+                  },
+                  "schema": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  },
+                  "allowExternalLinks": {
+                    "type": "boolean"
+                  },
+                  "enableWebSearch": {
+                    "type": "boolean"
+                  },
+                  "includeSubdomains": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "urls"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_extract"
+            },
+            {
+              "description": "\nAutonomous web research agent. This is a separate AI agent layer that independently browses the internet, searches for information, navigates through pages, and extracts structured data based on your query. You describe what you need, and the agent figures out where to find it.\n\n**How it works:** The agent performs web searches, follows links, reads pages, and gathers data autonomously. This runs **asynchronously** - it returns a job ID immediately, and you poll `firecrawl_agent_status` to check when complete and retrieve results.\n\n**IMPORTANT - Async workflow with patient polling:**\n1. Call `firecrawl_agent` with your prompt/schema → returns job ID immediately\n2. Poll `firecrawl_agent_status` with the job ID to check progress\n3. **Keep polling for at least 2-3 minutes** - agent research typically takes 1-5 minutes for complex queries\n4. Poll every 15-30 seconds until status is \"completed\" or \"failed\"\n5. Do NOT give up after just a few polling attempts - the agent needs time to research\n\n**Expected wait times:**\n- Simple queries with provided URLs: 30 seconds - 1 minute\n- Complex research across multiple sites: 2-5 minutes\n- Deep research tasks: 5+ minutes\n\n**Best for:** Complex research tasks where you don't know the exact URLs; multi-source data gathering; finding information scattered across the web; extracting data from JavaScript-heavy SPAs that fail with regular scrape.\n**Not recommended for:** Simple single-page scraping where you know the URL (use scrape with JSON format instead - faster and cheaper).\n\n**Arguments:**\n- prompt: Natural language description of the data you want (required, max 10,000 characters)\n- urls: Optional array of URLs to focus the agent on specific pages\n- schema: Optional JSON schema for structured output\n\n**Prompt Example:** \"Find the founders of Firecrawl and their backgrounds\"\n**Usage Example (start agent, then poll patiently for results):**\n```json\n{\n  \"name\": \"firecrawl_agent\",\n  \"arguments\": {\n    \"prompt\": \"Find the top 5 AI startups founded in 2024 and their funding amounts\",\n    \"schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"startups\": {\n          \"type\": \"array\",\n          \"items\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"name\": { \"type\": \"string\" },\n              \"funding\": { \"type\": \"string\" },\n              \"founded\": { \"type\": \"string\" }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n```\nThen poll with `firecrawl_agent_status` every 15-30 seconds for at least 2-3 minutes.\n\n**Usage Example (with URLs - agent focuses on specific pages):**\n```json\n{\n  \"name\": \"firecrawl_agent\",\n  \"arguments\": {\n    \"urls\": [\"https://docs.firecrawl.dev\", \"https://firecrawl.dev/pricing\"],\n    \"prompt\": \"Compare the features and pricing information from these pages\"\n  }\n}\n```\n**Returns:** Job ID for status checking. Use `firecrawl_agent_status` to poll for results.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 10000
+                  },
+                  "urls": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "schema": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "prompt"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_agent"
+            },
+            {
+              "description": "\nCheck the status of an agent job and retrieve results when complete. Use this to poll for results after starting an agent with `firecrawl_agent`.\n\n**IMPORTANT - Be patient with polling:**\n- Poll every 15-30 seconds\n- **Keep polling for at least 2-3 minutes** before considering the request failed\n- Complex research can take 5+ minutes - do not give up early\n- Only stop polling when status is \"completed\" or \"failed\"\n\n**Usage Example:**\n```json\n{\n  \"name\": \"firecrawl_agent_status\",\n  \"arguments\": {\n    \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n}\n```\n**Possible statuses:**\n- processing: Agent is still researching - keep polling, do not give up\n- completed: Research finished - response includes the extracted data\n- failed: An error occurred (only stop polling on this status)\n\n**Returns:** Status, progress, and results (if completed) of the agent job.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_agent_status"
+            },
+            {
+              "description": "\nCreate a browser session for code execution via CDP (Chrome DevTools Protocol).\n\n**Best for:** Running code (Python/JS) that interacts with a live browser page, multi-step browser automation, sessions with profiles that survive across multiple tool calls.\n**Not recommended for:** Simple page scraping (use firecrawl_scrape instead).\n\n**Arguments:**\n- ttl: Total session lifetime in seconds (30-3600, optional)\n- activityTtl: Idle timeout in seconds (10-3600, optional)\n- streamWebView: Whether to enable live view streaming (optional)\n- profile: Save and reuse browser state (cookies, localStorage) across sessions (optional)\n  - name: Profile name (sessions with the same name share state)\n  - saveChanges: Whether to save changes back to the profile (default: true)\n\n**Usage Example:**\n```json\n{\n  \"name\": \"firecrawl_browser_create\",\n  \"arguments\": {\n    \"profile\": { \"name\": \"my-profile\", \"saveChanges\": true }\n  }\n}\n```\n**Returns:** Session ID, CDP URL, and live view URL.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "ttl": {
+                    "type": "number",
+                    "minimum": 30,
+                    "maximum": 3600
+                  },
+                  "activityTtl": {
+                    "type": "number",
+                    "minimum": 10,
+                    "maximum": 3600
+                  },
+                  "streamWebView": {
+                    "type": "boolean"
+                  },
+                  "profile": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128
+                      },
+                      "saveChanges": {
+                        "default": true,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "saveChanges"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": "firecrawl_browser_create"
+            },
+            {
+              "description": "\nExecute code in a browser session. Supports agent-browser commands (bash), Python, or JavaScript.\n\n**Best for:** Browser automation, navigating pages, clicking elements, extracting data, multi-step browser workflows.\n**Requires:** An active browser session (create one with firecrawl_browser_create first).\n\n**Arguments:**\n- sessionId: The browser session ID (required)\n- code: The code to execute (required)\n- language: \"bash\", \"python\", or \"node\" (optional, defaults to \"bash\")\n\n**Recommended: Use bash with agent-browser commands** (pre-installed in every sandbox):\n```json\n{\n  \"name\": \"firecrawl_browser_execute\",\n  \"arguments\": {\n    \"sessionId\": \"session-id-here\",\n    \"code\": \"agent-browser open https://example.com\",\n    \"language\": \"bash\"\n  }\n}\n```\n\n**Common agent-browser commands:**\n- `agent-browser open <url>` — Navigate to URL\n- `agent-browser snapshot` — Get accessibility tree with clickable refs (for AI)\n- `agent-browser snapshot -i -c` — Interactive elements only, compact\n- `agent-browser click @e5` — Click element by ref from snapshot\n- `agent-browser type @e3 \"text\"` — Type into element\n- `agent-browser fill @e3 \"text\"` — Clear and fill element\n- `agent-browser get text @e1` — Get text content\n- `agent-browser get title` — Get page title\n- `agent-browser get url` — Get current URL\n- `agent-browser screenshot [path]` — Take screenshot\n- `agent-browser scroll down` — Scroll page\n- `agent-browser wait 2000` — Wait 2 seconds\n- `agent-browser --help` — Full command reference\n\n**For Playwright scripting, use Python** (has proper async/await support):\n```json\n{\n  \"name\": \"firecrawl_browser_execute\",\n  \"arguments\": {\n    \"sessionId\": \"session-id-here\",\n    \"code\": \"await page.goto('https://example.com')\\ntitle = await page.title()\\nprint(title)\",\n    \"language\": \"python\"\n  }\n}\n```\n\n**Note:** Prefer bash (agent-browser) or Python.\n**Returns:** Execution result including stdout, stderr, and exit code.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "sessionId": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "language": {
+                    "type": "string",
+                    "enum": [
+                      "bash",
+                      "python",
+                      "node"
+                    ]
+                  }
+                },
+                "required": [
+                  "sessionId",
+                  "code"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_browser_execute"
+            },
+            {
+              "description": "\nDestroy a browser session.\n\n**Usage Example:**\n```json\n{\n  \"name\": \"firecrawl_browser_delete\",\n  \"arguments\": {\n    \"sessionId\": \"session-id-here\"\n  }\n}\n```\n**Returns:** Success confirmation.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "sessionId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sessionId"
+                ],
+                "additionalProperties": false
+              },
+              "name": "firecrawl_browser_delete"
+            },
+            {
+              "description": "\nList browser sessions, optionally filtered by status.\n\n**Usage Example:**\n```json\n{\n  \"name\": \"firecrawl_browser_list\",\n  \"arguments\": {\n    \"status\": \"active\"\n  }\n}\n```\n**Returns:** Array of browser sessions.\n",
+              "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "destroyed"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": "firecrawl_browser_list"
+            }
+          ]
+        },
+        "jsonrpc": "2.0",
+        "id": 1
+      },
+      "response_is_sse": true,
+      "response_status": 200,
+      "latency_ms": 31,
+      "http_method": null,
+      "http_path": null
+    },
+    {
+      "type": "jsonrpc_request",
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+          "name": "firecrawl_scrape",
+          "arguments": {
+            "url": "https://example.com"
+          }
+        }
+      },
+      "response": {
+        "result": {
+          "content": [
+            {
+              "text": "Tool 'firecrawl_scrape' execution failed: Unauthorized: Invalid token",
+              "type": "text"
+            }
+          ],
+          "isError": true
+        },
+        "jsonrpc": "2.0",
+        "id": 2
+      },
+      "response_is_sse": true,
+      "response_status": 200,
+      "latency_ms": 503,
+      "http_method": null,
+      "http_path": null
+    }
+  ]
+}

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,0 +1,1 @@
+mcp-recorder>=0.3.0

--- a/integration/scenarios.yml
+++ b/integration/scenarios.yml
@@ -1,0 +1,16 @@
+schema_version: "1.0"
+
+target: http://localhost:3000
+
+redact:
+  server_url: false
+
+scenarios:
+  protocol_and_errors:
+    description: "Protocol handshake, tool schema listing, and error handling"
+    actions:
+      - list_tools
+      - call_tool:
+          name: firecrawl_scrape
+          arguments:
+            url: "https://example.com"


### PR DESCRIPTION
## Problem

No regression tests exist - CI only runs `pnpm build`. When schemas or tools change, tool calls can break silently.

## Solution

Adds snapshot-based regression tests that verify the MCP protocol surface - handshake, tool schemas, and error handling on every PR. Any change to a tool name, parameter type, or schema shows up as a diff in CI.

Zero changes to existing files. Adds a standalone `integration.yml` workflow.

Uses [mcp-recorder](https://github.com/devhelmhq/mcp-recorder) for recording and verification. No Firecrawl API key needed in CI, the server runs with a dummy key.

Updating cassettes after intentional changes: `mcp-recorder verify --cassette ... --target ... --update`

## Test plan

- [x] Verified locally — 4/4 interactions pass
- [ ] CI workflow runs on this PR