### PR TITLE
feat: make HTTP streamable stateless mode configurable via FASTMCP_STATELESS env

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ env HTTP_STREAMABLE_SERVER=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecra
 
 Use the url: http://localhost:3000/mcp
 
+By default the server runs in **stateless** mode (one transient session per request). Clients that rely on persistent MCP sessions — including those built on the official `modelcontextprotocol/go-sdk` — should opt into **stateful** mode by setting `FASTMCP_STATELESS=false`:
+
+```bash
+env HTTP_STREAMABLE_SERVER=true FASTMCP_STATELESS=false FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
+```
+
 ### Installing via Smithery (Legacy)
 
 To install Firecrawl for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@mendableai/mcp-server-firecrawl):

--- a/src/index.ts
+++ b/src/index.ts
@@ -1256,7 +1256,11 @@ if (
     httpStream: {
       port: PORT,
       host: HOST,
-      stateless: true,
+      // Stateless mode is the safe default for serverless / horizontally
+      // scaled deployments. Clients built on the official
+      // `modelcontextprotocol/go-sdk` (stateful by design) require
+      // session-tracking mode; set `FASTMCP_STATELESS=false` to opt in.
+      stateless: process.env.FASTMCP_STATELESS !== 'false',
     },
   };
 } else {


### PR DESCRIPTION
## Summary

Makes the HTTP streamable `stateless` option configurable via `FASTMCP_STATELESS` env var, matching the convention already used by the underlying `firecrawl-fastmcp` / `punkpeye/fastmcp` framework. Default behavior is preserved (`stateless: true`).

## Motivation

MCP clients built on the official [`modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk) (`StreamableClientTransport`) expect stateful session semantics. When connecting to a firecrawl-mcp instance running in `HTTP_STREAMABLE_SERVER` mode, the client receives a `Mcp-Session-Id` header in the initialize response, then passes it back on subsequent requests — but because the server is stateless, it replies `session not found` and the connection fails.

This prevents self-hosted Firecrawl integrations with Go-based MCP clients (e.g. [picoclaw](https://github.com/sipeed/picoclaw)-based agents) from working out of the box. Downstream users are currently forced to patch the compiled JS to work around it.

## Change

`src/index.ts:1259` — single-line change:

```diff
-      stateless: true,
+      stateless: process.env.FASTMCP_STATELESS !== 'false',
```

Plus a short README note explaining when to set `FASTMCP_STATELESS=false`.

Backward compatible — default remains `true` (stateless). Stateful mode is opt-in via `FASTMCP_STATELESS=false`.

## Testing

- Built locally (`pnpm install --frozen-lockfile && pnpm run build`); compiled JS contains the expected `FASTMCP_STATELESS !== 'false'` expression.
- Runtime verification: with `FASTMCP_STATELESS=false`, the server log changes from `Starting server in stateless mode` to `server is running on HTTP Stream` (FastMCP's stateful path).
- Integration with `modelcontextprotocol/go-sdk` v1.4.1 `StreamableClientTransport`: client successfully connects, lists all tools (12), and calls `firecrawl_scrape` / `firecrawl_crawl` / `firecrawl_search` / `firecrawl_map` end-to-end after applying this change.

## Alternatives considered

- **CLI flag**: rejected — no CLI arg parser in current firecrawl-mcp.
- **Flip default to stateful**: rejected — potential breaking change for existing HTTP streamable users (serverless / LB'd deployments).
- **`FASTMCP_STATELESS` env**: *chosen* — matches the documented FastMCP convention (see [punkpeye/fastmcp README § Stateless Mode](https://github.com/punkpeye/fastmcp#stateless-mode)), backward compatible, no breaking changes.