### PR TITLE
fix(security): validate firecrawl_extract URLs with z.string().url()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -773,7 +773,7 @@ Extract structured information from web pages using LLM capabilities. Supports b
 **Returns:** Extracted structured data as defined by your schema.
 `,
   parameters: z.object({
-    urls: z.array(z.string()),
+    urls: z.array(z.string().url()),
     prompt: z.string().optional(),
     schema: z.record(z.string(), z.any()).optional(),
     allowExternalLinks: z.boolean().optional(),


### PR DESCRIPTION
## Summary
Require each entry in \irecrawl_extract\'\urls\ to satisfy \z.string().url()\, matching other tools that accept HTTP(S) URLs.

## Why
\irecrawl_crawl\ URL validation is being tightened elsewhere (e.g. #210). \extract\ still accepted arbitrary strings in \urls\, which could confuse callers or weaken defense-in-depth.

## Test plan
- [x] \
pm install --ignore-scripts && npx tsc --noEmit\
