### PR TITLE
fix(search): remove regex lookahead from domain schema pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,10 @@ const searchDomainSchema = z
   .string()
   .trim()
   .toLowerCase()
+  .min(1)
+  .max(253)
   .regex(
-    /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/,
+    /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/,
     'Domain must be a valid hostname without protocol or path'
   );
 


### PR DESCRIPTION
## Summary

The `searchDomainSchema` in `src/index.ts` uses a regex with a lookahead assertion `(?=.{1,253}$)` to validate total hostname length. JSON Schema's `pattern` keyword does not support lookahead assertions (per the ECMA 262 subset it uses), causing LLM providers to reject the tool schema:

```
Error from provider: Regex lookahead (?=...) is not supported in JSON Schema pattern:
'^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$'
```

This blocks all Firecrawl tools from loading in clients that forward schemas to model providers (e.g., OpenCode, VS Code MCP extensions).

## Fix

- Remove the lookahead `(?=.{1,253}$)` from the regex
- Add `.min(1).max(253)` Zod constraints instead, which translate to `minLength`/`maxLength` in JSON Schema (fully supported)
- The regex itself still validates hostname label format (each label 1-63 chars, alphanumeric with hyphens, dot-separated)

### Before
```typescript
const searchDomainSchema = z
  .string()
  .trim()
  .toLowerCase()
  .regex(
    /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/,
    'Domain must be a valid hostname without protocol or path'
  );
```

### After
```typescript
const searchDomainSchema = z
  .string()
  .trim()
  .toLowerCase()
  .min(1)
  .max(253)
  .regex(
    /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/,
    'Domain must be a valid hostname without protocol or path'
  );
```

## Testing

- Build passes (`npm run build`)
- Validated against test domains:
  - **Valid**: `example.com`, `sub.example.com`, `a.b.c.d.example.co.uk`, `x.io` — all pass
  - **Invalid**: `""`, `-invalid.com`, `https://example.com`, `example.com/path`, `.com`, `a`, `example-.com` — all correctly rejected
- Confirmed generated JSON Schema no longer contains lookahead assertions

## Related Issues

- #112 — Incompatible JSON Schema ($dynamicRef) in Firecrawl MCP server tools
- #196 — Request that the format: uri be removed from the schema
