### PR TITLE
feat: add firecrawl_ask + firecrawl_docs_search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ Use this guide to select the right tool for your task:
 | crawl        | Multi-page extraction (with limits) | markdown/html[]            |
 | search       | Web search for info                 | results[]                  |
 | agent        | Complex multi-source research       | JSON (structured data)     |
+| ask          | **Diagnose** a failing/unexpected Firecrawl call | Diagnosis + fix params |
+| docs_search  | **Look up** how a Firecrawl feature/parameter works | Docs-grounded answer + citations |
 | browser      | Interactive multi-step automation (deprecated) | Session with live browser  |
 
 ### Format Selection Guide
@@ -819,7 +821,51 @@ Check the status of an agent job and retrieve results when complete. Use this to
 - `completed`: Research finished - response includes the extracted data
 - `failed`: An error occurred
 
-### 11. Browser Create (`firecrawl_browser_create`) — Deprecated
+### 11. Ask the AI Support Agent (`firecrawl_ask`)
+
+Diagnose a failing or unexpected Firecrawl call. The AI support agent inspects job logs, account state, credit usage, and the docs, then returns a 2-4 sentence prose diagnosis plus machine-readable `fixParameters` you can apply directly. Typical latency: 15-30 seconds.
+
+**Use this WHENEVER another firecrawl_* tool returns an error, an empty result, or output that doesn't match what the user asked for** — instead of guessing or apologizing, call `firecrawl_ask` first and apply the suggested fix.
+
+```json
+{
+  "name": "firecrawl_ask",
+  "arguments": {
+    "question": "scrape of https://example.com returned empty markdown",
+    "rationale": "User wants to scrape example.com to feed an LLM summarization pipeline.",
+    "jobId": "scrape-abc-123-def",
+    "context": { "formats": ["markdown"], "status": "completed-empty" }
+  }
+}
+```
+
+**Recommended loop:**
+
+1. Run the operation; capture any error and the job id from the response.
+2. If the result looks wrong, call `firecrawl_ask` with the failing question, the `jobId`, and a short `rationale` describing user intent.
+3. If `fixParameters` come back, apply them and rerun the original tool. The agent often validates fixes against the live API (`validation.tested: true, validation.result: "success"`) — those are safe to apply directly.
+4. If `confidence` is `low` and `feedback` is non-null, escalate to human support.
+
+**Returns:** Envelope with `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `feedback`, `usage`, `durationMs`.
+
+### 12. Search Firecrawl Docs (`firecrawl_docs_search`)
+
+Search Firecrawl's official public documentation for "how do I…" questions. Returns a concise, docs-grounded answer with citations to the source pages — answers come from current Firecrawl docs, not stale training data.
+
+**Prefer this over a generic web search** for any Firecrawl-specific question (parameters, endpoints, features, status codes, billing). Use `firecrawl_ask` instead when you're debugging an actual failing call.
+
+```json
+{
+  "name": "firecrawl_docs_search",
+  "arguments": {
+    "question": "how do I verify webhook signatures?"
+  }
+}
+```
+
+**Returns:** `requestId`, `answer`, `evidence` (array of `{pathOrUrl, reason}` citing the docs pages), `usage`, `durationMs`. The `evidence[].pathOrUrl` values can be fed back into `firecrawl_scrape` if you need the full text of a cited page.
+
+### 13. Browser Create (`firecrawl_browser_create`) — Deprecated
 
 > **Deprecated:** Prefer `firecrawl_scrape` + `firecrawl_interact` instead. Interact lets you scrape a page and then click, fill forms, and navigate without managing sessions manually.
 
@@ -850,7 +896,7 @@ Create a cloud browser session for interactive automation.
 
 - Session ID, CDP URL, and live view URL
 
-### 12. Browser Execute (`firecrawl_browser_execute`) — Deprecated
+### 14. Browser Execute (`firecrawl_browser_execute`) — Deprecated
 
 > **Deprecated:** Prefer `firecrawl_scrape` + `firecrawl_interact` instead.
 
@@ -894,7 +940,7 @@ Execute code in a browser session. Supports agent-browser commands (bash), Pytho
 }
 ```
 
-### 13. Browser List (`firecrawl_browser_list`) — Deprecated
+### 15. Browser List (`firecrawl_browser_list`) — Deprecated
 
 > **Deprecated:** Prefer `firecrawl_scrape` + `firecrawl_interact` instead.
 
@@ -909,7 +955,7 @@ List browser sessions, optionally filtered by status.
 }
 ```
 
-### 14. Browser Delete (`firecrawl_browser_delete`) — Deprecated
+### 16. Browser Delete (`firecrawl_browser_delete`) — Deprecated
 
 > **Deprecated:** Prefer `firecrawl_scrape` + `firecrawl_interact` instead.
 

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ Diagnose a failing or unexpected Firecrawl call. The AI support agent inspects j
 3. If `fixParameters` come back, apply them and rerun the original tool. The agent often validates fixes against the live API (`validation.tested: true, validation.result: "success"`) — those are safe to apply directly.
 4. If `confidence` is `low` and `feedback` is non-null, escalate to human support.
 
-**Returns:** Envelope with `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `feedback`, `usage`, `durationMs`.
+**Returns:** Envelope with `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `feedback`, `durationMs`.
 
 ### 12. Search Firecrawl Docs (`firecrawl_docs_search`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.firecrawl/firecrawl-mcp-server",
   "title": "Firecrawl MCP Server",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
-  "version": "3.7.4",
+  "version": "3.16.0",
   "repository": {
     "url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.7.4",
+      "version": "3.16.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1469,7 +1469,7 @@ Diagnose why a Firecrawl call failed or returned unexpected results. The AI supp
 }
 \`\`\`
 
-**Returns:** JSON envelope with \`requestId\`, \`answer\` (prose), \`confidence\` (high/medium/low), \`fixParameters\` (object|null — apply these to retry the failing call), \`validation\` (whether the agent tested the fix), \`feedback\` (non-null when stuck), \`usage\`, and \`durationMs\`.
+**Returns:** JSON envelope with \`requestId\`, \`answer\` (prose), \`confidence\` (high/medium/low), \`fixParameters\` (object|null — apply these to retry the failing call), \`validation\` (whether the agent tested the fix), \`feedback\` (non-null when stuck), and \`durationMs\`.
 `,
   parameters: z.object({
     question: z

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,58 @@ function asText(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
 
+// Default base for the customer-facing /v2/support/* endpoints. The
+// Firecrawl API proxies these through to the support-agent service.
+const SUPPORT_API_BASE = 'https://api.firecrawl.dev';
+
+/**
+ * Call a /v2/support/* endpoint (currently /support/ask and /support/docs-search).
+ *
+ * The SDK doesn't expose these yet, so we POST directly. The bearer is the
+ * customer's Firecrawl API key — same auth as every other Firecrawl request,
+ * just resolved per-session like every other tool. Honors FIRECRAWL_API_URL
+ * so self-hosted-with-proxy deployments work too.
+ */
+async function callSupportEndpoint(
+  session: SessionData | undefined,
+  endpoint: '/v2/support/ask' | '/v2/support/docs-search',
+  body: Record<string, unknown>
+): Promise<string> {
+  const apiKey = session?.firecrawlApiKey || process.env.FIRECRAWL_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'Firecrawl API key is required for support endpoints (set FIRECRAWL_API_KEY or pass via session).'
+    );
+  }
+  const apiUrl =
+    (process.env.FIRECRAWL_API_URL && process.env.FIRECRAWL_API_URL.trim()) ||
+    SUPPORT_API_BASE;
+  const url = `${apiUrl.replace(/\/$/, '')}${endpoint}`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    let detail = response.statusText;
+    if (text) detail = `${detail} — ${text.slice(0, 500)}`;
+    throw new Error(
+      `Firecrawl support endpoint ${endpoint} returned ${response.status}: ${detail}`
+    );
+  }
+  try {
+    return asText(JSON.parse(text));
+  } catch {
+    return text;
+  }
+}
+
 // scrape tool (v2 semantics, minimal args)
 // Centralized scrape params (used by scrape, and referenced in search/crawl scrapeOptions)
 
@@ -1374,6 +1426,153 @@ Stop an interact session for a scraped page. Call this when you are done interac
     log.info('Stopping interact session', { scrapeId });
     const res = await client.stopInteraction(scrapeId);
     return asText(res);
+  },
+});
+
+server.addTool({
+  name: 'firecrawl_ask',
+  annotations: {
+    title: 'Diagnose a Firecrawl issue with the AI support agent',
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
+  description: `
+Diagnose why a Firecrawl call failed or returned unexpected results. The AI support agent inspects job logs, account state, credit usage, and the docs, then returns a 2-4 sentence prose diagnosis plus machine-readable \`fixParameters\` you can apply directly. Typical latency: 15-30 seconds.
+
+**Best for:** Debugging a failing or unexpected Firecrawl call. Use this WHENEVER another firecrawl_* tool returns an error, an empty result, or output that doesn't match what the user asked for — instead of guessing or apologizing, call firecrawl_ask first and apply the suggested fix.
+**Not recommended for:** "How do I…" questions about Firecrawl features (use firecrawl_docs_search instead). Generic web search (use firecrawl_search). Pre-flight what-ifs ("what would happen if…") — only call after a real failure.
+**Common mistakes:** Re-running the same broken call hoping for a different result. Telling the user the run failed without trying firecrawl_ask. Skipping \`jobId\` when you have one (it lets the agent pull the actual run's logs instead of guessing from the question).
+
+**When to call:**
+- A previous firecrawl_scrape / firecrawl_crawl / firecrawl_search / firecrawl_map / firecrawl_agent / firecrawl_browser_* / firecrawl_interact call failed or returned unexpected output.
+- The user is confused by Firecrawl behavior ("why is it returning empty?", "why am I being rate-limited?", "why did the crawl stop early?").
+- You're about to recommend the user open a support ticket — try firecrawl_ask first.
+
+**Recipe — agent-friendly debugging loop:**
+1. Run the operation. Capture any error and the job id (the \`id\` or \`scrape_id\` field on the response).
+2. If the result looks wrong, call firecrawl_ask with the failing question, the jobId, and a short rationale describing user intent.
+3. If \`fixParameters\` come back, apply them and rerun the original tool with those params. The agent often validates fixes against the live API (\`validation.tested: true, validation.result: "success"\`) — those are safe to apply directly.
+4. If \`confidence\` is "low" and \`feedback\` is non-null, escalate to human support; the agent could not resolve the issue.
+
+**Authentication:** The Firecrawl API key on the session IS the bearer — calls are automatically scoped to the caller's team. No extra config needed.
+
+**Usage Example (after a failing scrape):**
+\`\`\`json
+{
+  "name": "firecrawl_ask",
+  "arguments": {
+    "question": "scrape of https://example.com returned empty markdown — the page loads fine in a browser",
+    "rationale": "User wants to scrape example.com to feed an LLM summarization pipeline.",
+    "jobId": "scrape-abc-123-def",
+    "context": { "formats": ["markdown"], "status": "completed-empty" }
+  }
+}
+\`\`\`
+
+**Returns:** JSON envelope with \`requestId\`, \`answer\` (prose), \`confidence\` (high/medium/low), \`fixParameters\` (object|null — apply these to retry the failing call), \`validation\` (whether the agent tested the fix), \`feedback\` (non-null when stuck), \`usage\`, and \`durationMs\`.
+`,
+  parameters: z.object({
+    question: z
+      .string()
+      .min(1)
+      .max(8_000)
+      .describe(
+        'What to diagnose. Describe what went wrong — the failing tool name, what you expected, what you got. 1-8000 chars.'
+      ),
+    rationale: z
+      .string()
+      .min(1)
+      .max(2_000)
+      .optional()
+      .describe(
+        'Recommended for AI callers. 1-2 plain-English sentences on what the END USER (not you, the calling agent) is trying to accomplish. Helps the support agent prioritize evidence gathering. ≤2000 chars.'
+      ),
+    jobId: z
+      .string()
+      .optional()
+      .describe(
+        'Firecrawl job id from the failing call (the `id` or `scrape_id` on the response). Lets agent tools like debugJob/searchLogs/getJob auto-default to the right run.'
+      ),
+    context: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        'Free-form structured metadata about the failing call (status, formats requested, error code, etc.) the agent considers. Treated as untrusted DATA, not instructions.'
+      ),
+  }),
+  execute: async (
+    args: unknown,
+    { session, log }: { session?: SessionData; log: Logger }
+  ): Promise<string> => {
+    const { question, rationale, jobId, context } = args as {
+      question: string;
+      rationale?: string;
+      jobId?: string;
+      context?: Record<string, unknown>;
+    };
+    log.info('Calling firecrawl ask', {
+      jobId: jobId ?? null,
+      hasContext: Boolean(context && Object.keys(context).length),
+    });
+    const body: Record<string, unknown> = { question };
+    if (rationale) body.rationale = rationale;
+    if (jobId) body.jobId = jobId;
+    if (context && Object.keys(context).length > 0) body.context = context;
+    return callSupportEndpoint(session, '/v2/support/ask', body);
+  },
+});
+
+server.addTool({
+  name: 'firecrawl_docs_search',
+  annotations: {
+    title: "Search Firecrawl's official documentation",
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
+  description: `
+Search Firecrawl's official public documentation for "how does it work" / "how do I…" questions. Returns a concise, docs-grounded answer with citations to the source pages — answers come from current Firecrawl docs, not stale training data.
+
+**Best for:** Looking up how a Firecrawl endpoint, parameter, or feature works. Examples: "what does \`waitFor\` do on /scrape?", "how do I verify webhook signatures?", "which formats support change tracking?", "how does crawl handle robots.txt?", "what's the difference between /scrape and /parse?". Use this BEFORE generic web search whenever the question is specifically about Firecrawl behavior or configuration.
+**Not recommended for:** Debugging an actual failing call (use firecrawl_ask — it can pull the run's logs). General web search unrelated to Firecrawl (use firecrawl_search).
+**Common mistakes:** Asking firecrawl_search or doing your own training-data answer for Firecrawl-specific questions when firecrawl_docs_search would be both more accurate (current docs) and cheaper than a full web search.
+
+**When to call:**
+- The user asks "how do I…" about a Firecrawl feature/endpoint/parameter.
+- You need to look up which option name to pass, what a status code means, how billing works for a specific endpoint, or how a feature behaves.
+- You're onboarding to a Firecrawl feature you've never used (webhooks, change tracking, batch scrape, agent extraction, browser sessions, etc.).
+
+**Authentication:** The Firecrawl API key on the session IS the bearer.
+
+**Usage Example:**
+\`\`\`json
+{
+  "name": "firecrawl_docs_search",
+  "arguments": {
+    "question": "how do I verify webhook signatures?"
+  }
+}
+\`\`\`
+
+**Returns:** JSON with \`requestId\`, \`answer\` (prose), \`evidence\` (array of \`{pathOrUrl, reason}\` citing the docs pages used), \`usage\`, and \`durationMs\`. The \`evidence[].pathOrUrl\` values can be fed back into firecrawl_scrape if you need the full text of a cited page.
+`,
+  parameters: z.object({
+    question: z
+      .string()
+      .min(1)
+      .max(8_000)
+      .describe(
+        "Plain-English question about Firecrawl's features, endpoints, parameters, or behavior. 1-8000 chars."
+      ),
+  }),
+  execute: async (
+    args: unknown,
+    { session, log }: { session?: SessionData; log: Logger }
+  ): Promise<string> => {
+    const { question } = args as { question: string };
+    log.info('Calling firecrawl docs-search');
+    return callSupportEndpoint(session, '/v2/support/docs-search', {
+      question,
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

Two new MCP tools wrap the customer-facing `/v2/support/*` endpoints exposed at `api.firecrawl.dev` (which proxies to the support-agent service):

| Tool | Use when |
|---|---|
| **`firecrawl_ask`** | Debugging — a `firecrawl_*` call failed, returned an empty result, or behaved unexpectedly. The AI support agent inspects job logs + account state + docs and returns a diagnosis with machine-readable `fixParameters` you can apply directly. |
| **`firecrawl_docs_search`** | Learning — "how do I…" questions about Firecrawl features, parameters, endpoints, status codes, billing. Returns a docs-grounded answer with citations. |

Both auth automatically with the per-session `FIRECRAWL_API_KEY` — same as every other tool, calls are team-scoped server-side.

## Why this matters for agents

Today, when a `firecrawl_scrape`/`firecrawl_crawl`/etc. call fails or returns weird output, agents typically:
1. Apologize and tell the user to file a support ticket, or
2. Guess at fixes based on stale training data and burn credits on retries.

After this PR, the right move is `firecrawl_ask` — the support agent inspects the actual run's logs, often validates a fix against the live API, and returns the corrected parameters as JSON the calling agent can apply directly. The tool descriptions push agents toward this loop explicitly:

> **Best for:** Debugging a failing or unexpected Firecrawl call. Use this WHENEVER another firecrawl_* tool returns an error, an empty result, or output that doesn't match what the user asked for — instead of guessing or apologizing, call firecrawl_ask first and apply the suggested fix.

`firecrawl_docs_search` solves the parallel problem on the learning side — instead of returning out-of-date answers from training data when the user asks "how do webhooks work in Firecrawl?", agents now have a tool that grounds the answer in the current docs.

## Implementation

**`src/index.ts`:**

- New `callSupportEndpoint(session, endpoint, body)` helper near the existing `asText()` utility — POSTs directly to `/v2/support/*` with the session's API key (the SDK doesn't expose these yet). Defaults to `https://api.firecrawl.dev` but honors `FIRECRAWL_API_URL` when set, so self-hosted-with-proxy deployments work.
- Two new `server.addTool({...})` registrations after `firecrawl_interact_stop`:
  - `firecrawl_ask` — schema: `question` (1-8000 chars, required) + optional `rationale` (1-2000), `jobId`, `context`. Mirrors the upstream `AskRequestSchema` post-cleanup (no `model` / `maxSteps` / `firecrawlApi*` knobs).
  - `firecrawl_docs_search` — schema: `question` (1-8000 chars, required) only.
- Both tools use the existing `readOnlyHint: true, openWorldHint: false` annotations and the same Best-for / Not-recommended / Common-mistakes / Recipe / Returns description pattern as `firecrawl_scrape` and `firecrawl_search`.

**`README.md`:**

- Quick Reference Table — add `ask` and `docs_search` rows.
- Available Tools — full sections (#11 ask, #12 docs_search), renumbering the subsequent deprecated browser tools to #13–#16.

## Testing the change

After this lands, in any MCP client (Claude Desktop, Cursor, etc.):

```text
firecrawl_ask({
  "question": "scrape of https://example.com returned empty markdown",
  "rationale": "User wants to scrape example.com to feed an LLM summarization pipeline.",
  "jobId": "scrape-abc-123-def"
})
```

Should return a `{ requestId, answer, confidence, fixParameters, validation, … }` envelope from the support agent within ~15-30 seconds.

```text
firecrawl_docs_search({
  "question": "how do I verify webhook signatures?"
})
```

Should return `{ answer, evidence: [{ pathOrUrl, reason }], … }` with citations to the relevant docs pages.

## Test plan

- [ ] Build clean: `pnpm install && pnpm build`
- [ ] `firecrawl_ask` returns a valid envelope when called with a real failing job id from the user's team
- [ ] `firecrawl_docs_search` returns docs-grounded results with citations
- [ ] Both tools surface clear errors when `FIRECRAWL_API_KEY` is missing
- [ ] `FIRECRAWL_API_URL` override is honored (self-hosted proxy scenario)

## Companion changes

- [firecrawl-web#2096](https://github.com/firecrawl/firecrawl-web/pull/2096) — uses `/v2/support/ask` from the playground Debug Issue modal.
- [support-agent#4](https://github.com/firecrawl/support-agent/pull/4) — tightens the customer-facing `AskRequestSchema` (drops `model`, `maxSteps`, `firecrawlApi*`).
- [firecrawl-docs#917](https://github.com/firecrawl/firecrawl-docs/pull/917) — keeps `/support/*` out of the Elixir SDK source-of-truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)