### PR TITLE
Bump to 3.19.1; document meaningful-change judge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.19.1] - 2026-05-27
+
+### Changed
+
+- Refined monitor goal guidance for meaningful-change monitoring.
+- Documented `isMeaningful`, `judgment`, and `meaningfulChanges` monitor results.
+
 ## [3.19.0] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -872,6 +872,8 @@ Create and manage recurring page monitors. Monitors run scheduled scrapes or cra
 
 Use `page` or `pages` plus `goal`. The MCP server builds the monitor request with a 30-minute schedule and the API enables meaningful-change judging automatically.
 
+Meaningful-change judging runs automatically when `goal` is set. Page webhooks expose `isMeaningful` and `judgment` on `monitor.page` events.
+
 Write goals as concise 2-3 sentence monitor instructions. Say what should trigger an alert, preserve any scope the user gave, and include intent-specific exclusions only when obvious from the request. Generic noise such as whitespace, formatting-only changes, request IDs, tracking params, generic metadata, and unrelated page chrome is already handled by the judge, so do not repeat it in every goal. If the user is vague, keep the goal broad; if they ask for broad monitoring or "any change", preserve that. If the user says they do not care about something, include that explicitly.
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -168,6 +168,8 @@ Create a Firecrawl monitor — a recurring scrape or crawl that diffs each resul
 
 Prefer the simple path: pass \`page\` or \`pages\` plus \`goal\`. The tool will create a scrape monitor with a 30-minute schedule and meaningful-change judging enabled by the API. Use \`body\` only for advanced requests such as crawl targets, JSON change tracking, custom retention, or manual \`judgeEnabled\` control.
 
+Meaningful-change judge: set \`goal\` to a plain-language description of what the user actually cares about. \`judgeEnabled\` defaults to true when \`goal\` is set, so providing \`goal\` is enough. Page webhooks expose \`isMeaningful\` and \`judgment\` on \`monitor.page\` events.
+
 Simple fields:
 - \`page\`: one page URL to monitor.
 - \`pages\`: multiple page URLs to monitor.


### PR DESCRIPTION
Bump package version to 3.19.1 and add a CHANGELOG entry. Update README and src/monitor.ts to refine guidance for meaningful-change monitoring: note that judgeEnabled defaults to true when a goal is provided and that page webhooks expose isMeaningful and judgment (and document meaningfulChanges in the changelog). These are documentation clarifications to help users write goals and consume monitor page events.