### PR TITLE
Handle CLI metadata flags before server auth

### DIFF
--- a/src/cli-info.ts
+++ b/src/cli-info.ts
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises';
+
+export type CliInfoResult = {
+  exitCode: number;
+  output: string;
+  stream: 'stdout' | 'stderr';
+};
+
+const HELP_TEXT = `Usage: firecrawl-mcp [options]
+
+Starts the Firecrawl MCP server.
+
+Options:
+  -h, --help      Print this help message
+  -v, --version   Print the installed package version
+
+Configuration:
+  FIRECRAWL_API_KEY      Firecrawl cloud API key
+  FIRECRAWL_API_URL      Self-hosted Firecrawl API URL
+`;
+
+async function readPackageVersion(packageJsonUrl: URL): Promise<string> {
+  const packageJson = JSON.parse(await readFile(packageJsonUrl, 'utf8')) as {
+    version?: unknown;
+  };
+
+  return typeof packageJson.version === 'string' ? packageJson.version : 'unknown';
+}
+
+export async function getCliInfoResult(
+  argv: string[],
+  packageJsonUrl = new URL('../package.json', import.meta.url)
+): Promise<CliInfoResult | undefined> {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    return {
+      exitCode: 0,
+      output: HELP_TEXT,
+      stream: 'stdout',
+    };
+  }
+
+  if (argv.includes('--version') || argv.includes('-v')) {
+    return {
+      exitCode: 0,
+      output: `${await readPackageVersion(packageJsonUrl)}\n`,
+      stream: 'stdout',
+    };
+  }
+
+  const unknownFlag = argv.find((arg) => arg.startsWith('-'));
+  if (unknownFlag) {
+    return {
+      exitCode: 1,
+      output: `error: unknown option '${unknownFlag}'\nRun firecrawl-mcp --help for usage.\n`,
+      stream: 'stderr',
+    };
+  }
+
+  return undefined;
+}
+
+export async function handleCliInfoFlags(argv = process.argv.slice(2)): Promise<void> {
+  const result = await getCliInfoResult(argv);
+
+  if (!result) return;
+
+  const target = result.stream === 'stdout' ? process.stdout : process.stderr;
+  target.write(result.output);
+  process.exit(result.exitCode);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,12 @@ import type { IncomingHttpHeaders } from 'http';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { z } from 'zod';
+import { handleCliInfoFlags } from './cli-info.js';
 import { registerMonitorTools } from './monitor.js';
 
 dotenv.config({ debug: false, quiet: true });
+
+await handleCliInfoFlags();
 
 interface SessionData {
   /**


### PR DESCRIPTION
## Summary

- handle `--help` / `-h` and `--version` / `-v` before starting the MCP server
- return a concise unknown-option error for unsupported top-level flags before auth/config validation
- keep normal server startup behavior unchanged when no metadata flag is provided

Fixes #256.

## Validation

- `npm run build`
- `node dist/index.js --help` exits 0 and prints usage
- `node dist/index.js --version` exits 0 and prints `3.20.2`
- `node dist/index.js -h` exits 0 and prints usage
- `node dist/index.js -v` exits 0 and prints `3.20.2`
- `node dist/index.js --definitely-not-a-real-flag` exits 1 with an unknown-option error
- `node dist/index.js` still exits 1 with the existing `FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` validation when env vars are unset
- `git diff --check`

Not run: `npm run lint` because the current package install does not provide an `eslint` executable.