### PR TITLE
Docs: sync README with the actual tools and install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,25 @@ A Model Context Protocol (MCP) server that brings [Firecrawl](https://github.com
 - Scrape any URL into clean, structured data
 - Interact with pages — click, navigate, and operate
 - Deep research with autonomous agent
+- Monitor pages for changes with webhook/email alerts
+- arXiv + GitHub research tools (when research access is enabled)
 - Automatic retries and rate limiting
 - Cloud and self-hosted support
-- SSE support
+- Streamable HTTP support
 
 > Play around with [our MCP Server on MCP.so's playground](https://mcp.so/playground?server=firecrawl-mcp-server) or on [Klavis AI](https://www.klavis.ai/mcp-servers).
 
 ## Installation
+
+You can either use our remote hosted URL or run the server locally. Get your API key from https://firecrawl.dev/app/api-keys.
+
+### Remote hosted URL (recommended)
+
+No install required — point your MCP client at:
+
+```
+https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp
+```
 
 ### Running with npx
 
@@ -99,6 +111,42 @@ Add this to your `./codeium/windsurf/model_config.json`:
 }
 ```
 
+### Running on Claude Code
+
+Add the server with the Claude Code CLI — remote hosted URL (recommended) or local npx:
+
+```bash
+# Remote hosted URL (recommended)
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
+
+# Or run locally via npx
+claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp
+```
+
+### Running on Google Antigravity
+
+In the Agent sidebar, open the "…" menu → **MCP Servers** → **View raw config**, then add:
+
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "YOUR_FIRECRAWL_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Save and click **Refresh** in the Antigravity MCP interface.
+
+### Running on n8n
+
+Add an **AI Agent** node → add a **Tool** → **MCP Client Tool**, set the endpoint to `https://mcp.firecrawl.dev/{YOUR_FIRECRAWL_API_KEY}/v2/mcp`, **Server Transport** to **HTTP Streamable**, and **Authentication** to **None**.
+
 ### Running with Streamable HTTP Local Mode
 
 To run the server using Streamable HTTP locally instead of the default stdio transport:
@@ -107,7 +155,7 @@ To run the server using Streamable HTTP locally instead of the default stdio tra
 env HTTP_STREAMABLE_SERVER=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
 ```
 
-Use the url: http://localhost:3000/mcp
+Use the url: http://localhost:3000/v2/mcp (or the remote `https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp`)
 
 ### Installing via Smithery (Legacy)
 
@@ -321,12 +369,15 @@ Use this guide to select the right tool for your task:
 
 - **If you know the exact URL(s) you want:**
   - For one: use **scrape** (with JSON format for structured data)
-  - For many: use **batch_scrape**
+  - For many: call **scrape** per URL, or use **crawl** for a whole section
 - **If you need to discover URLs on a site:** use **map**
 - **If you want to search the web for info:** use **search**
 - **If you need complex research across multiple unknown sources:** use **agent**
 - **If you want to analyze a whole site or section:** use **crawl** (with limits!)
 - **If you need interactive browser automation** (click, type, navigate): use **scrape** + **interact**
+- **If you need to convert a file (PDF, DOCX, …) to markdown:** use **parse**
+- **If you want to watch a page for changes over time:** use **monitor**
+- **If you're researching academic papers or GitHub history:** use the **research** tools (when enabled)
 
 ### Quick Reference Table
 
@@ -334,11 +385,14 @@ Use this guide to select the right tool for your task:
 | ------------ | ---------------------------------------------- | ------------------------------ |
 | scrape       | Single page content                            | JSON (preferred) or markdown   |
 | interact     | Interact with a scraped page                   | Execution result               |
-| batch_scrape | Multiple known URLs                            | JSON (preferred) or markdown[] |
 | map          | Discovering URLs on a site                     | URL[]                          |
 | crawl        | Multi-page extraction (with limits)            | markdown/html[]                |
 | search       | Web search for info                            | results[]                      |
+| extract      | Structured data from known URLs                | JSON (structured data)         |
 | agent        | Complex multi-source research                  | JSON (structured data)         |
+| parse        | Local/remote file (PDF, DOCX, …) → markdown    | markdown                       |
+| monitor      | Watch pages for changes over time              | monitor/check objects          |
+| research_*   | arXiv papers + GitHub history (when enabled)   | ranked results                 |
 
 ### Format Selection Guide
 
@@ -434,72 +488,7 @@ Scrape content from a single URL with advanced options.
 
 - JSON structured data, markdown, branding profile, or other formats as specified.
 
-### 2. Batch Scrape Tool (`firecrawl_batch_scrape`)
-
-Scrape multiple URLs efficiently with built-in rate limiting and parallel processing.
-
-**Best for:**
-
-- Retrieving content from multiple pages, when you know exactly which pages to scrape.
-
-**Not recommended for:**
-
-- Discovering URLs (use map first if you don't know the URLs)
-- Scraping a single page (use scrape)
-
-**Common mistakes:**
-
-- Using batch_scrape with too many URLs at once (may hit rate limits or token overflow)
-
-**Prompt Example:**
-
-> "Get the content of these three blog posts: [url1, url2, url3]."
-
-**Usage Example:**
-
-```json
-{
-  "name": "firecrawl_batch_scrape",
-  "arguments": {
-    "urls": ["https://example1.com", "https://example2.com"],
-    "options": {
-      "formats": ["markdown"],
-      "onlyMainContent": true
-    }
-  }
-}
-```
-
-**Returns:**
-
-- Response includes operation ID for status checking:
-
-```json
-{
-  "content": [
-    {
-      "type": "text",
-      "text": "Batch operation queued with ID: batch_1. Use firecrawl_check_batch_status to check progress."
-    }
-  ],
-  "isError": false
-}
-```
-
-### 3. Check Batch Status (`firecrawl_check_batch_status`)
-
-Check the status of a batch operation.
-
-```json
-{
-  "name": "firecrawl_check_batch_status",
-  "arguments": {
-    "id": "batch_1"
-  }
-}
-```
-
-### 4. Map Tool (`firecrawl_map`)
+### 2. Map Tool (`firecrawl_map`)
 
 Map a website to discover all indexed URLs on the site.
 
@@ -536,7 +525,7 @@ Map a website to discover all indexed URLs on the site.
 
 - Array of URLs found on the site
 
-### 5. Search Tool (`firecrawl_search`)
+### 3. Search Tool (`firecrawl_search`)
 
 Search the web and optionally extract content from search results.
 
@@ -562,8 +551,8 @@ Search the web and optionally extract content from search results.
   "arguments": {
     "query": "latest AI research papers 2023",
     "limit": 5,
-    "lang": "en",
-    "country": "us",
+    "location": "United States",
+    "sources": ["web"],
     "scrapeOptions": {
       "formats": ["markdown"],
       "onlyMainContent": true,
@@ -581,7 +570,7 @@ Search the web and optionally extract content from search results.
 
 > "Find the latest research papers on AI published in 2023."
 
-### 5b. Search Feedback Tool (`firecrawl_search_feedback`)
+### 3b. Search Feedback Tool (`firecrawl_search_feedback`)
 
 Sends structured feedback on a previous `firecrawl_search` result. The first feedback per search id refunds 1 credit and improves Firecrawl's search quality. Idempotent per search id.
 
@@ -623,7 +612,7 @@ Sends structured feedback on a previous `firecrawl_search` result. The first fee
 
 - `{ success, feedbackId, creditsRefunded, alreadySubmitted? }` JSON.
 
-### 6. Crawl Tool (`firecrawl_crawl`)
+### 4. Crawl Tool (`firecrawl_crawl`)
 
 Starts an asynchronous crawl job on a website and extract content from all pages.
 
@@ -641,7 +630,7 @@ Starts an asynchronous crawl job on a website and extract content from all pages
 
 **Common mistakes:**
 
-- Setting limit or maxDepth too high (causes token overflow)
+- Setting limit or maxDiscoveryDepth too high (causes token overflow)
 - Using crawl for a single page (use scrape instead)
 
 **Prompt Example:**
@@ -655,7 +644,7 @@ Starts an asynchronous crawl job on a website and extract content from all pages
   "name": "firecrawl_crawl",
   "arguments": {
     "url": "https://example.com/blog/*",
-    "maxDepth": 2,
+    "maxDiscoveryDepth": 2,
     "limit": 100,
     "allowExternalLinks": false,
     "deduplicateSimilarURLs": true
@@ -679,7 +668,7 @@ Starts an asynchronous crawl job on a website and extract content from all pages
 }
 ```
 
-### 7. Check Crawl Status (`firecrawl_check_crawl_status`)
+### 5. Check Crawl Status (`firecrawl_check_crawl_status`)
 
 Check the status of a crawl job.
 
@@ -696,7 +685,7 @@ Check the status of a crawl job.
 
 - Response includes the status of the crawl job:
 
-### 8. Extract Tool (`firecrawl_extract`)
+### 6. Extract Tool (`firecrawl_extract`)
 
 Extract structured information from web pages using LLM capabilities. Supports both cloud AI and self-hosted LLM extraction.
 
@@ -769,7 +758,67 @@ When using a self-hosted instance, the extraction will use your configured LLM. 
 }
 ```
 
-### 9. Agent Tool (`firecrawl_agent`)
+### 7. Parse Tool (`firecrawl_parse`)
+
+Parse a file from the **local filesystem** into clean markdown or structured JSON, via a self-hosted Firecrawl API's `/v2/parse` endpoint.
+
+**Requires:** `FIRECRAWL_API_URL` set to a self-hosted Firecrawl instance (parse is not available on the default cloud API).
+
+**Best for:** Extracting content from a local document without hosting it on the public web first.
+**Not recommended for:** Remote URLs (use `firecrawl_scrape`).
+**Supported file types:** `.html`, `.htm`, `.xhtml`, `.pdf`, `.docx`, `.doc`, `.odt`, `.rtf`, `.xlsx`, `.xls`.
+
+```json
+{
+  "name": "firecrawl_parse",
+  "arguments": {
+    "filePath": "/absolute/path/to/document.pdf",
+    "formats": ["markdown"],
+    "parsers": ["pdf"]
+  }
+}
+```
+
+For specific data points, use JSON format with a schema (same rules as `firecrawl_scrape`). Set `redactPII: true` to redact personal data.
+
+### 8. Interact Tool (`firecrawl_interact`)
+
+Interact with a previously scraped page in a live browser session — click buttons, fill forms, extract dynamic content, or navigate deeper. Scrape a page first with `firecrawl_scrape`, then pass the returned `scrapeId`.
+
+**Arguments:**
+
+- `scrapeId`: scrape job ID from a previous `firecrawl_scrape` call (required)
+- `prompt`: natural-language instruction (use this OR `code`)
+- `code`: code to execute in the session (use this OR `prompt`)
+- `language`: `bash`, `python`, or `node` (default `node`, only used with `code`)
+- `timeout`: seconds, 1–300 (default 30)
+
+```json
+{
+  "name": "firecrawl_interact",
+  "arguments": {
+    "scrapeId": "scrape-id-from-previous-scrape",
+    "prompt": "Click on the first product and tell me its price"
+  }
+}
+```
+
+The response includes `liveViewUrl` and `interactiveLiveViewUrl` to watch or control the session in real time.
+
+### 9. Stop Interact Session (`firecrawl_interact_stop`)
+
+Stop an interact session for a scraped page to free resources when you're done.
+
+```json
+{
+  "name": "firecrawl_interact_stop",
+  "arguments": {
+    "scrapeId": "scrape-id-from-previous-scrape"
+  }
+}
+```
+
+### 10. Agent Tool (`firecrawl_agent`)
 
 Autonomous web research agent. This is a separate AI agent layer that independently browses the internet, searches for information, navigates through pages, and extracts structured data based on your query.
 
@@ -850,7 +899,7 @@ Then poll with `firecrawl_agent_status` using the returned job ID.
 
 - Job ID for status checking. Use `firecrawl_agent_status` to poll for results.
 
-### 10. Check Agent Status (`firecrawl_agent_status`)
+### 11. Check Agent Status (`firecrawl_agent_status`)
 
 Check the status of an agent job and retrieve results when complete. Use this to poll for results after starting an agent.
 
@@ -871,7 +920,7 @@ Check the status of an agent job and retrieve results when complete. Use this to
 - `completed`: Research finished - response includes the extracted data
 - `failed`: An error occurred
 
-### 11. Monitor Tools (`firecrawl_monitor_*`)
+### 12. Monitor Tools (`firecrawl_monitor_*`)
 
 Create and manage recurring page monitors. Monitors run scheduled scrapes or crawls, diff each result against the last retained snapshot, and can notify by webhook or email.
 
@@ -938,6 +987,25 @@ Pass `body` when you need crawl targets, JSON change tracking, custom retention,
 - `firecrawl_monitor_run`: trigger a check now.
 - `firecrawl_monitor_checks`: list checks, optionally filtered by status.
 - `firecrawl_monitor_check`: get page-level results, including `diff`, `snapshot`, `judgment.meaningful`, and `judgment.meaningfulChanges`.
+
+### 13. Research Tools (`firecrawl_research_*`)
+
+A suite of academic and code research tools, available **only when research access is enabled** for your session. They search and read arXiv papers and GitHub history.
+
+- **`firecrawl_research_search_papers`** — semantic (HyDE) search over arXiv abstracts; returns ranked papers (id, title, abstract). Args: `query`, `k`, `authors`, `categories`, `from`, `to`. Run several distinct framings of a question for better recall.
+- **`firecrawl_research_related_papers`** — expand from seed arXiv ids via the citation graph, ranked to a natural-language `intent`. Args: `seed_ids`, `intent`, `mode` (`similar` | `citers` | `references`), `k`, `rerank`.
+- **`firecrawl_research_read_paper`** — read the most relevant full-text passages of one paper to verify a claim. Args: `arxiv_id`, `question`, `k`.
+- **`firecrawl_research_search_github`** — search GitHub issue/PR history and repository READMEs. Args: `query`, `k`.
+
+```json
+{
+  "name": "firecrawl_research_search_papers",
+  "arguments": {
+    "query": "retrieval-augmented generation for code",
+    "k": 40
+  }
+}
+```
 
 ## Logging System
 

--- a/README.md
+++ b/README.md
@@ -388,15 +388,14 @@ Use this guide to select the right tool for your task:
 | map          | Discovering URLs on a site                     | URL[]                          |
 | crawl        | Multi-page extraction (with limits)            | markdown/html[]                |
 | search       | Web search for info                            | results[]                      |
-| extract      | Structured data from known URLs                | JSON (structured data)         |
 | agent        | Complex multi-source research                  | JSON (structured data)         |
-| parse        | Local/remote file (PDF, DOCX, …) → markdown    | markdown                       |
+| parse        | Local file (PDF, DOCX, …) → markdown — self-hosted only | markdown              |
 | monitor      | Watch pages for changes over time              | monitor/check objects          |
-| research_*   | arXiv papers + GitHub history (when enabled)   | ranked results                 |
+| research_*   | arXiv papers + GitHub history — experimental, opt-in    | ranked results        |
 
 ### Format Selection Guide
 
-When using `scrape` or `batch_scrape`, choose the right format:
+When using `scrape`, choose the right format:
 
 - **JSON format (recommended for most cases):** Use when you need specific data from a page. Define a schema based on what you need to extract. This keeps responses small and avoids context window overflow.
 - **Markdown format (use sparingly):** Only when you genuinely need the full page content, such as reading an entire article for summarization or analyzing page structure.
@@ -413,12 +412,12 @@ Scrape content from a single URL with advanced options.
 
 **Not recommended for:**
 
-- Extracting content from multiple pages (use batch_scrape for known URLs, or map + batch_scrape to discover URLs first, or crawl for full page content)
+- Extracting content from multiple pages (call scrape per URL, or use crawl for full page content)
 - When you're unsure which page contains the information (use search)
 
 **Common mistakes:**
 
-- Using scrape for a list of URLs (use batch_scrape instead).
+- Using markdown format by default when you only need specific fields (use JSON format with a schema).
 - Using markdown format by default (use JSON format to extract only what you need).
 
 **Choosing the right format:**
@@ -499,7 +498,7 @@ Map a website to discover all indexed URLs on the site.
 
 **Not recommended for:**
 
-- When you already know which specific URL you need (use scrape or batch_scrape)
+- When you already know which specific URL you need (use scrape)
 - When you need the content of the pages (use scrape after mapping)
 
 **Common mistakes:**
@@ -623,10 +622,10 @@ Starts an asynchronous crawl job on a website and extract content from all pages
 **Not recommended for:**
 
 - Extracting content from a single page (use scrape)
-- When token limits are a concern (use map + batch_scrape)
+- When token limits are a concern (use map, then scrape specific URLs)
 - When you need fast results (crawling can be slow)
 
-**Warning:** Crawl responses can be very large and may exceed token limits. Limit the crawl depth and number of pages, or use map + batch_scrape for better control.
+**Warning:** Crawl responses can be very large and may exceed token limits. Limit the crawl depth and number of pages, or use map then scrape specific URLs for better control.
 
 **Common mistakes:**
 
@@ -685,80 +684,7 @@ Check the status of a crawl job.
 
 - Response includes the status of the crawl job:
 
-### 6. Extract Tool (`firecrawl_extract`)
-
-Extract structured information from web pages using LLM capabilities. Supports both cloud AI and self-hosted LLM extraction.
-
-**Best for:**
-
-- Extracting specific structured data like prices, names, details.
-
-**Not recommended for:**
-
-- When you need the full content of a page (use scrape)
-- When you're not looking for specific structured data
-
-**Arguments:**
-
-- `urls`: Array of URLs to extract information from
-- `prompt`: Custom prompt for the LLM extraction
-- `systemPrompt`: System prompt to guide the LLM
-- `schema`: JSON schema for structured data extraction
-- `allowExternalLinks`: Allow extraction from external links
-- `enableWebSearch`: Enable web search for additional context
-- `includeSubdomains`: Include subdomains in extraction
-
-When using a self-hosted instance, the extraction will use your configured LLM. For cloud API, it uses Firecrawl's managed LLM service.
-**Prompt Example:**
-
-> "Extract the product name, price, and description from these product pages."
-
-**Usage Example:**
-
-```json
-{
-  "name": "firecrawl_extract",
-  "arguments": {
-    "urls": ["https://example.com/page1", "https://example.com/page2"],
-    "prompt": "Extract product information including name, price, and description",
-    "systemPrompt": "You are a helpful assistant that extracts product information",
-    "schema": {
-      "type": "object",
-      "properties": {
-        "name": { "type": "string" },
-        "price": { "type": "number" },
-        "description": { "type": "string" }
-      },
-      "required": ["name", "price"]
-    },
-    "allowExternalLinks": false,
-    "enableWebSearch": false,
-    "includeSubdomains": false
-  }
-}
-```
-
-**Returns:**
-
-- Extracted structured data as defined by your schema
-
-```json
-{
-  "content": [
-    {
-      "type": "text",
-      "text": {
-        "name": "Example Product",
-        "price": 99.99,
-        "description": "This is an example product description"
-      }
-    }
-  ],
-  "isError": false
-}
-```
-
-### 7. Parse Tool (`firecrawl_parse`)
+### 6. Parse Tool (`firecrawl_parse`)
 
 Parse a file from the **local filesystem** into clean markdown or structured JSON, via a self-hosted Firecrawl API's `/v2/parse` endpoint.
 
@@ -781,7 +707,7 @@ Parse a file from the **local filesystem** into clean markdown or structured JSO
 
 For specific data points, use JSON format with a schema (same rules as `firecrawl_scrape`). Set `redactPII: true` to redact personal data.
 
-### 8. Interact Tool (`firecrawl_interact`)
+### 7. Interact Tool (`firecrawl_interact`)
 
 Interact with a previously scraped page in a live browser session — click buttons, fill forms, extract dynamic content, or navigate deeper. Scrape a page first with `firecrawl_scrape`, then pass the returned `scrapeId`.
 
@@ -805,7 +731,7 @@ Interact with a previously scraped page in a live browser session — click butt
 
 The response includes `liveViewUrl` and `interactiveLiveViewUrl` to watch or control the session in real time.
 
-### 9. Stop Interact Session (`firecrawl_interact_stop`)
+### 8. Stop Interact Session (`firecrawl_interact_stop`)
 
 Stop an interact session for a scraped page to free resources when you're done.
 
@@ -818,7 +744,7 @@ Stop an interact session for a scraped page to free resources when you're done.
 }
 ```
 
-### 10. Agent Tool (`firecrawl_agent`)
+### 9. Agent Tool (`firecrawl_agent`)
 
 Autonomous web research agent. This is a separate AI agent layer that independently browses the internet, searches for information, navigates through pages, and extracts structured data based on your query.
 
@@ -899,7 +825,7 @@ Then poll with `firecrawl_agent_status` using the returned job ID.
 
 - Job ID for status checking. Use `firecrawl_agent_status` to poll for results.
 
-### 11. Check Agent Status (`firecrawl_agent_status`)
+### 10. Check Agent Status (`firecrawl_agent_status`)
 
 Check the status of an agent job and retrieve results when complete. Use this to poll for results after starting an agent.
 
@@ -920,7 +846,7 @@ Check the status of an agent job and retrieve results when complete. Use this to
 - `completed`: Research finished - response includes the extracted data
 - `failed`: An error occurred
 
-### 12. Monitor Tools (`firecrawl_monitor_*`)
+### 11. Monitor Tools (`firecrawl_monitor_*`)
 
 Create and manage recurring page monitors. Monitors run scheduled scrapes or crawls, diff each result against the last retained snapshot, and can notify by webhook or email.
 
@@ -988,9 +914,9 @@ Pass `body` when you need crawl targets, JSON change tracking, custom retention,
 - `firecrawl_monitor_checks`: list checks, optionally filtered by status.
 - `firecrawl_monitor_check`: get page-level results, including `diff`, `snapshot`, `judgment.meaningful`, and `judgment.meaningfulChanges`.
 
-### 13. Research Tools (`firecrawl_research_*`)
+### 12. Research Tools (`firecrawl_research_*`)
 
-A suite of academic and code research tools, available **only when research access is enabled** for your session. They search and read arXiv papers and GitHub history.
+An **experimental, opt-in** suite of academic and code research tools that search and read arXiv papers and GitHub history. They are **not exposed on the standard hosted MCP** — enable them with `FIRECRAWL_RESEARCH=true` (local/self-hosted) or a `?research=true` query param on the HTTP endpoint.
 
 - **`firecrawl_research_search_papers`** — semantic (HyDE) search over arXiv abstracts; returns ranked papers (id, title, abstract). Args: `query`, `k`, `authors`, `categories`, `from`, `to`. Run several distinct framings of a question for better recall.
 - **`firecrawl_research_related_papers`** — expand from seed arXiv ids via the citation graph, ranked to a natural-language `intent`. Args: `seed_ids`, `intent`, `mode` (`similar` | `citers` | `references`), `k`, `rerank`.


### PR DESCRIPTION
The README had drifted from both the code and the [docs](https://docs.firecrawl.dev/mcp-server). I verified the registered tools and their **availability guards** against `src/` on `main` (v3.20.4) and brought the README in line with what the hosted MCP actually exposes.

### Tools
- **Removed** `firecrawl_batch_scrape` + `firecrawl_check_batch_status` — **not registered** in the code (only in prose / `src/legacy/`). Also cleaned up stale `batch_scrape` prose references.
- **Removed** the `firecrawl_extract` section (per product direction).
- **Added** real-but-undocumented tools, with correct availability:
  - `firecrawl_parse` — **self-hosted only** (registered only when `CLOUD_SERVICE !== 'true'`; needs `FIRECRAWL_API_URL`).
  - `firecrawl_interact` / `firecrawl_interact_stop`.
  - `firecrawl_research_*` — **experimental / opt-in** (`FIRECRAWL_RESEARCH=true` or `?research=true`); not on the standard hosted MCP.
- Renumbered the **Available Tools** sections and refreshed the quick-reference table + "How to Choose a Tool".

### Install & params
- Added the **remote hosted URL** (`https://mcp.firecrawl.dev/{KEY}/v2/mcp`) and **Claude Code / Google Antigravity / n8n** sections.
- Fixed the local Streamable HTTP path `/mcp` → `/v2/mcp`.
- Fixed crawl `maxDepth` → `maxDiscoveryDepth`; modernized search params (`lang`/`country` → `location`/`sources`).
- Features: "SSE support" → "Streamable HTTP support"; added monitor + research bullets.

### Note for maintainers
The published docs at docs.firecrawl.dev/mcp-server still list a **browser-session suite** (`firecrawl_browser_create/execute/delete/list`) that is **not in the code** — looks like a docs bug (flagging separately; not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)