### PR TITLE
Sync server.json version metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.firecrawl/firecrawl-mcp-server",
   "title": "Firecrawl MCP Server",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
-  "version": "3.7.5",
+  "version": "3.20.6",
   "repository": {
     "url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.20.2",
+      "version": "3.20.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
`server.json` still had older version values even though `package.json` and the published `firecrawl-mcp` package are at `3.20.6`.
This updates both the top-level server version and the package entry version to `3.20.6`. I checked the JSON/package version sync, confirmed the npm registry version, ran `pnpm build`, and `git diff --check`.
Fixes #235
