### PR TITLE
Add glama.json to claim the server on glama.ai

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "rakshith48"
+  ]
+}


### PR DESCRIPTION
Adds a root `glama.json` so this official server can be claimed and managed on the [glama.ai](https://glama.ai/mcp/servers) MCP directory (which auto-indexes from `awesome-mcp-servers`). Claiming enables maintainer controls over the listing (metadata, badges, updates).

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": [
    "rakshith48"
  ]
}
```

Per glama's "claim a server that belongs to an organization" flow: add this file at the repo root, then the listed maintainer logs in with GitHub to claim. Single new file, no code changes.