### PR TITLE
docs: add Gamut to supported clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ To install Firecrawl for Claude Desktop automatically via [Smithery](https://smi
 npx -y @smithery/cli install @mendableai/mcp-server-firecrawl --client claude
 ```
 
+### Running on Gamut
+
+Connect Firecrawl to a [Gamut](https://www.gamut.so/mcp/developer-tools/firecrawl) agent:
+
+1. In your Gamut agent, go to **Connections** and click **Add Connection**.
+2. Search for **Firecrawl** and click **+** to add it.
+3. Authenticate with your Firecrawl account when prompted.
+
 ### Running on VS Code
 
 For one-click installation, click one of the install buttons below...


### PR DESCRIPTION
Adds [Gamut](https://www.gamut.so) setup instructions alongside the existing client guides (Cursor, Windsurf, VS Code, Claude Desktop).

Gamut is an AI agent platform with native MCP support. Users can connect to the Firecrawl MCP Server directly from the Gamut interface.