### PR TITLE
chore: release firecrawl-mcp 3.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",


### PR DESCRIPTION
## Summary

Bumps `firecrawl-mcp` from `3.22.0` to `3.22.1` as the trailing release PR for the merged surface-parity cleanup batch.

## Why

The content PRs were intentionally merged without individual version bumps so the cleanup batch can publish once instead of as fragmented releases. This patch bump covers the already-merged MCP changes from #294, #295, #296, and #297.

## Validation

- `npm run build`
- `git diff --check`

## Notes

No source or README changes are included here; this PR is package-version-only.
