### PR TITLE
fix: sync server.json version metadata with package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Verify server.json version metadata
+        run: pnpm run check:server-json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,19 +49,7 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Sync MCP Registry version
-        run: |
-          node -e "
-            const fs = require('fs');
-            const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            const manifest = JSON.parse(fs.readFileSync('server.json', 'utf8'));
-            manifest.version = packageJson.version;
-            for (const pkg of manifest.packages ?? []) {
-              if (pkg.registryType === 'npm' && pkg.identifier === 'firecrawl-mcp') {
-                pkg.version = packageJson.version;
-              }
-            }
-            fs.writeFileSync('server.json', JSON.stringify(manifest, null, 2) + '\n');
-          "
+        run: pnpm run sync:server-json
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write .",
+    "sync:server-json": "node scripts/sync-server-json.mjs",
+    "check:server-json": "node scripts/check-server-json-version.mjs",
     "prepare": "npm run build",
     "publish-prod": "npm run build && npm publish",
     "publish-beta": "npm run build && npm publish --tag beta"

--- a/scripts/check-server-json-version.mjs
+++ b/scripts/check-server-json-version.mjs
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const manifest = JSON.parse(fs.readFileSync("server.json", "utf8"));
+
+const errors = [];
+
+if (manifest.version !== packageJson.version) {
+  errors.push(
+    `server.json version (${manifest.version}) does not match package.json (${packageJson.version})`,
+  );
+}
+
+const npmPackage = (manifest.packages ?? []).find(
+  (pkg) => pkg.registryType === "npm" && pkg.identifier === "firecrawl-mcp",
+);
+
+if (!npmPackage) {
+  errors.push("server.json is missing firecrawl-mcp npm package entry");
+} else if (npmPackage.version !== packageJson.version) {
+  errors.push(
+    `server.json packages[firecrawl-mcp].version (${npmPackage.version}) does not match package.json (${packageJson.version})`,
+  );
+}
+
+if (errors.length > 0) {
+  console.error("server.json version check failed:\n- " + errors.join("\n- "));
+  console.error("\nRun: pnpm run sync:server-json");
+  process.exit(1);
+}
+
+console.log(`server.json version matches package.json (${packageJson.version})`);

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const manifest = JSON.parse(fs.readFileSync("server.json", "utf8"));
+
+manifest.version = packageJson.version;
+
+for (const pkg of manifest.packages ?? []) {
+  if (pkg.registryType === "npm" && pkg.identifier === "firecrawl-mcp") {
+    pkg.version = packageJson.version;
+  }
+}
+
+fs.writeFileSync("server.json", JSON.stringify(manifest, null, 2) + "\n");
+
+console.log(`Synced server.json to package.json version ${packageJson.version}`);

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.firecrawl/firecrawl-mcp-server",
   "title": "Firecrawl MCP Server",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web.",
-  "version": "3.7.5",
+  "version": "3.22.2",
   "repository": {
     "url": "https://github.com/firecrawl/firecrawl-mcp-server.git",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "firecrawl-mcp",
-      "version": "3.22.1",
+      "version": "3.22.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Sync `server.json` registry metadata with `package.json` and add CI guardrails so version drift does not recur.

## Motivation

Fixes #235. The repo's `server.json` had drifted far behind `package.json` and npm (`3.7.5` / `3.22.1` vs `3.22.2`). The publish workflow already synced versions at publish time for the MCP registry, but those updates were never committed back to the repository.

## Changes

- Update `server.json` top-level `version` and npm package entry to `3.22.2`
- Add `scripts/sync-server-json.mjs` and `scripts/check-server-json-version.mjs`
- Add `pnpm run sync:server-json` and `pnpm run check:server-json`
- Run the check in CI after build
- Reuse the shared sync script in the publish workflow

## Tests

From repo root:

```bash
pnpm install
pnpm run build
pnpm run check:server-json
pnpm run sync:server-json
```

All passed locally.

## Notes

When bumping `package.json` version, maintainers should run `pnpm run sync:server-json` and commit the updated `server.json` alongside the bump. CI will fail if they forget.

Fixes #235