### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ See the [MCP server docs](https://docs.firecrawl.dev/mcp-server) and the [agent 
 env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
 ```
 
+### Running on Autohand Code
+
+Connect to Firecrawl's hosted MCP endpoint without an API key:
+
+```bash
+autohand mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp
+```
+
+For the local server with an API key, use:
+
+```bash
+autohand mcp add firecrawl env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+
 ### Manual Installation
 
 ```bash


### PR DESCRIPTION
## What changed

Adds an Autohand Code setup section beside the existing `npx` and client instructions.

The section covers both Firecrawl's hosted HTTP endpoint and the local `npx` server with `FIRECRAWL_API_KEY`, plus the project-scoped option.

## Verification

- Checked the commands against the current Autohand Code MCP CLI
- Ran `git diff --check`

This is a documentation-only change.
