### PR TITLE
fix(annotations): align firecrawl_search readOnlyHint with scrape tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1225,7 +1225,7 @@ server.addTool({
   name: 'firecrawl_search',
   annotations: {
     title: 'Search the web',
-    readOnlyHint: true, // Runs a web search and returns results; does not modify external sites.
+    readOnlyHint: SAFE_MODE, // Align with firecrawl_scrape: read-only in cloud/safe mode where interactive actions are disabled.
     openWorldHint: true, // Searches the open web across arbitrary domains and sources.
     destructiveHint: false, // Query-only; no destructive side effects on external entities.
   },

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -482,6 +482,14 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.ok(toolNames.includes('firecrawl_scrape'));
   assert.ok(toolNames.includes('firecrawl_search'));
   assert.ok(toolNames.includes('firecrawl_parse'));
+  const searchTool = tools.tools.find((tool) => tool.name === 'firecrawl_search');
+  const scrapeTool = tools.tools.find((tool) => tool.name === 'firecrawl_scrape');
+  assert.equal(
+    searchTool?.annotations?.readOnlyHint,
+    scrapeTool?.annotations?.readOnlyHint,
+    'firecrawl_search readOnlyHint should match firecrawl_scrape'
+  );
+  assert.equal(searchTool?.annotations?.readOnlyHint, false);
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 


### PR DESCRIPTION
## Summary

Set `firecrawl_search` `readOnlyHint` to `SAFE_MODE` so it matches `firecrawl_scrape` and reflects whether interactive `scrapeOptions.actions` are exposed in the tool schema.

## Motivation

`firecrawl_search` declared `readOnlyHint: true` while its input schema includes `scrapeOptions.actions` with `click`, `write`, `press`, and `executeJavascript` in self-hosted mode. MCP clients that honor `readOnlyHint` could skip confirmation prompts for a tool that can drive browser interactions. Reported in #311 via actlint `write-as-readonly`.

## Changes

- `src/index.ts`: `readOnlyHint: true` → `readOnlyHint: SAFE_MODE` on `firecrawl_search`
- `tests/mcp-smoke.test.mjs`: assert `firecrawl_search` and `firecrawl_scrape` share the same `readOnlyHint` in stdio (non-cloud) mode

## Tests

`npm test` — 9/9 pass (build + smoke tests)

## Notes

- Cloud mode (`CLOUD_SERVICE=true`) keeps `readOnlyHint: true` because interactive actions are omitted from the schema in safe mode.
- Self-hosted mode now reports `readOnlyHint: false`, consistent with `firecrawl_scrape`.

Fixes #311