### PR TITLE
fix(docker): bind Node to IPv4 loopback for NGINX upstream

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -36,6 +36,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV PORT=3000
+ENV HOST=127.0.0.1
 EXPOSE 8080
 
 CMD ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 set -e
 
+# Bind the Node app to IPv4 loopback so NGINX (upstream 127.0.0.1:3000) can
+# reach it. Default HOST=localhost resolves to ::1 on IPv6-enabled images,
+# which leaves NGINX unable to proxy (see issue #251).
+export HOST="${HOST:-127.0.0.1}"
+
 # Start Node app in background
 node dist/index.js &
 APP_PID=$!


### PR DESCRIPTION
## Summary

Set `HOST=127.0.0.1` in the bundled Docker service image so the Node MCP server listens on the same IPv4 loopback address that NGINX proxies to.

## Motivation

Fixes #251. On IPv6-enabled images, the default `HOST=localhost` can resolve to `::1`, while `docker/nginx.conf` upstream targets `127.0.0.1:3000`. That mismatch makes the provided container unreachable until users manually set `HOST=127.0.0.1`.

## Changes

- `docker/entrypoint.sh`: export `HOST=${HOST:-127.0.0.1}` before starting the Node process (runtime override still works)
- `Dockerfile.service`: document the default with `ENV HOST=127.0.0.1`

## Tests

- `pnpm test` — 9/9 passed
- composer-2.5 review: **APPROVE**

## Notes

- Scoped to the Docker service image only; non-Docker `HOST` behavior is unchanged.
- `CLOUD_SERVICE=true` deployments still bind `0.0.0.0` as before.