### PR TITLE
Evaluate native MCP routing instruction profiles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
+import { resolveMcpInstructions } from './instructions';
 
 dotenv.config({ debug: false, quiet: true });
 
@@ -384,7 +385,7 @@ const server = new FastMCP<SessionData>({
   name: 'firecrawl-fastmcp',
   version: packageVersion as `${number}.${number}.${number}`,
   ...{
-    instructions: `The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.`,
+    instructions: resolveMcpInstructions().content,
   },
   logger: new ConsoleLogger(),
   roots: { enabled: false },

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+
+export const STOCK_MCP_INSTRUCTIONS =
+  'The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.';
+
+export const AUTHENTICATED_ROUTER_INSTRUCTIONS = `Firecrawl is configured as the web data provider for this agent.
+
+For tasks that require current public-web data, prefer the Firecrawl tools on this server:
+- Use firecrawl_search to discover pages or research a topic when no URL is known.
+- Use firecrawl_scrape to read a known page and return clean content.
+- Use firecrawl_map to discover URLs on a site.
+- Use firecrawl_crawl for a bounded multi-page traversal.
+
+Do not use Firecrawl for local files, data already supplied by the user, or requests that explicitly require offline work, no web access, or another named tool. If a Firecrawl call cannot serve the request, explain the limitation or use an allowed alternative. After using firecrawl_search results, call firecrawl_search_feedback with the search ID.`;
+
+export const KEYLESS_ROUTER_INSTRUCTIONS = `Firecrawl is available in a restricted keyless mode for current public-web data.
+
+Use firecrawl_search to discover public pages and firecrawl_scrape to read a known public URL. Other Firecrawl operations require account authentication and must not be promised or selected in this mode.
+
+Do not use Firecrawl for local files, data already supplied by the user, or requests that explicitly require offline work, no web access, or another named tool. If the restricted tools cannot serve the request, explain that authentication is required or use an allowed alternative.`;
+
+export type McpInstructionsProfile =
+  | 'stock'
+  | 'router-authenticated-v1'
+  | 'router-keyless-v1';
+
+export function resolveMcpInstructions(
+  profile = process.env.FIRECRAWL_MCP_INSTRUCTIONS_PROFILE
+): { content: string; profile: McpInstructionsProfile; sha256: string } {
+  const normalized = profile?.trim() || 'stock';
+  let content: string;
+  let selected: McpInstructionsProfile;
+  switch (normalized) {
+    case 'stock':
+      selected = 'stock';
+      content = STOCK_MCP_INSTRUCTIONS;
+      break;
+    case 'router-authenticated-v1':
+      selected = 'router-authenticated-v1';
+      content = AUTHENTICATED_ROUTER_INSTRUCTIONS;
+      break;
+    case 'router-keyless-v1':
+      selected = 'router-keyless-v1';
+      content = KEYLESS_ROUTER_INSTRUCTIONS;
+      break;
+    default:
+      throw new Error(
+        `Unsupported FIRECRAWL_MCP_INSTRUCTIONS_PROFILE: ${normalized}`
+      );
+  }
+  return {
+    content,
+    profile: selected,
+    sha256: createHash('sha256').update(content, 'utf8').digest('hex'),
+  };
+}

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -298,6 +298,7 @@ test('HTTP cloud transport preserves Firecrawl OAuth and well-known routes', asy
   assert.match(initialize.headers.get('content-type') ?? '', /text\/event-stream/);
   const initializeMessage = parseSseJson(await initialize.text());
   assert.equal(initializeMessage.result.serverInfo.name, 'firecrawl-fastmcp');
+  assert.match(initializeMessage.result.instructions, /installed Firecrawl/);
 
   const toolsList = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
     body: JSON.stringify({
@@ -483,6 +484,45 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.ok(toolNames.includes('firecrawl_search'));
   assert.ok(toolNames.includes('firecrawl_parse'));
   assert.equal(stderr.includes('TypeError'), false, stderr);
+});
+
+test('stdio transport emits the authenticated router profile natively', async (t) => {
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_MCP_INSTRUCTIONS_PROFILE: 'router-authenticated-v1',
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  const init = await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'router-profile-test', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  assert.match(init.instructions, /prefer the Firecrawl tools/);
+  assert.match(init.instructions, /explicitly require offline work/);
+  assert.doesNotMatch(init.instructions, /FIRECRAWL_MCP_INSTRUCTIONS_PROFILE/);
+});
+
+test('stdio transport emits a capability-honest keyless router profile', async (t) => {
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: '',
+    FIRECRAWL_MCP_INSTRUCTIONS_PROFILE: 'router-keyless-v1',
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  const init = await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'keyless-router-profile-test', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  assert.match(init.instructions, /restricted keyless mode/);
+  assert.match(init.instructions, /firecrawl_search/);
+  assert.match(init.instructions, /firecrawl_scrape/);
+  assert.doesNotMatch(init.instructions, /Use firecrawl_(?:crawl|map|extract)/);
 });
 
 test('stdio transport calls Firecrawl API through a tool end to end', async (t) => {


### PR DESCRIPTION
## Summary
- preserve stock MCP instructions as the default
- add authenticated and keyless capability-honest experimental profiles
- deliver profiles only through native MCP `initialize.instructions`

## Experiment result — do not promote to default
P3 ran 384 immutable Convex-backed traces across Claude Sonnet 5 and Codex Terra using naturally discovered stdio MCP configuration with no Firecrawl CLI, skills, context card, forced `--mcp-config`, or injected instruction file.

- authenticated router profile: 0% → 0%, 0pp on both harnesses, adjusted p = 1.0
- keyless router profile: 0% → 0%, 0pp on both harnesses, adjusted p = 1.0
- safety: 1/96 matched regression; simultaneous upper bound 6.14%, above the 5% gate
- a separate eight-cell mechanism diagnostic found no behaviorally accessible profile-specific startup text in either harness

**Recommendation:** reject `initialize.instructions` as a router-card delivery surface for natural Claude Code and Codex CLI sessions. Keep stock instructions capability-honest, but do not merge these profiles as a routing feature unless maintainers explicitly want research-only profile support.

Decision artifact: Convex `kg23nxb3s0gvqg8pcdqc2szqwh8arz95`. Diagnostic artifact: Convex `kg27gt5j74h2d59jzzcp7s5zx98arfqp`. Raw traces remain in Convex.

## Verification
- `npm test` (11 passed)
- `npm run lint`
- GitHub `build` check passes
