### PR TITLE
docs(scrape): disclose maxAge freshness/speed tradeoff and liveness limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -384,7 +384,7 @@ const server = new FastMCP<SessionData>({
   name: 'firecrawl-fastmcp',
   version: packageVersion as `${number}.${number}.${number}`,
   ...{
-    instructions: `The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. Scrape requests may reuse recently indexed content; pass maxAge: 0 to bypass index reuse when freshness matters, and do not treat a successful page response as proof that a listed item (job, product) is still active. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.`,
+    instructions: `The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. Scrape requests may reuse recently indexed content; pass maxAge: 0 to bypass index reuse when freshness matters, and do not treat a successful page response as proof that the state represented by the page is current. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.`,
   },
   logger: new ConsoleLogger(),
   roots: { enabled: false },
@@ -1123,7 +1123,7 @@ If JSON extraction returns empty, minimal, or just navigation content, the page 
 \`\`\`
 **Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.
 **Freshness vs speed:** maxAge sets how recent indexed content must be to be reused — eligible results can return up to 500% faster; set maxAge: 0 to bypass index reuse when freshness matters.
-**Liveness:** a successful scrape does not confirm that the item it describes (job posting, listing) is still active — check the content for closed/expired signals and treat an engine-reported metadata.url that differs from the requested URL as possible redirect evidence; treat inconclusive evidence as unknown before irreversible actions.
+**Liveness:** a successful scrape does not confirm that the state represented by the page is current — check the content and source-specific status signals, treat an engine-reported metadata.url that differs from the requested URL as possible redirect evidence, and treat inconclusive evidence as unknown before actions that depend on current state.
 **Lockdown mode:** Set \`lockdown: true\` to serve the request only from the existing index/cache without any outbound network request. For air-gapped or compliance-constrained use where the request URL itself is considered sensitive. Errors on cache miss. Billed at 5 credits.
 **Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted.
 **Returns:** JSON structured data, markdown, branding profile, or other formats as specified.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1814,7 +1814,7 @@ Retrieve and extract content from one supplied URL through Firecrawl. Use this w
 
 This tool operates on a known page. For a set of pages use \`firecrawl_crawl\`, and to discover page URLs use \`firecrawl_map\` or \`firecrawl_search\`. Options include JavaScript render delay, cache age, main-content filtering, PII redaction, and lockdown cache-only retrieval. Browser actions may change the live page when interactive actions are enabled.
 
-Firecrawl may reuse recently indexed content instead of refetching the page; the default window is about two days and can vary by domain. Set \`maxAge: 0\` to force a live fetch. A successful response does not by itself confirm that the state it describes is still current.
+Firecrawl may reuse recently indexed content instead of refetching the page, and the reuse window varies by domain. Set \`maxAge: 0\` to force a live fetch, or a smaller \`maxAge\` to bound how stale reused content may be. A successful response does not by itself confirm that the state it describes is still current.
 
 Returns the selected content formats and page metadata.
 `,
@@ -1904,7 +1904,7 @@ Search web, news, or image sources and return ranked results. Operators include 
 
 For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
 
-\`scrapeOptions\` can attach extracted page content; pages fetched this way may reuse indexed content up to three days old and do not honor \`maxAge\`, so use \`firecrawl_scrape\` when a live fetch is required. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback.
+\`scrapeOptions\` can attach extracted page content; pages fetched this way use a fixed reuse window and ignore \`maxAge\`, so use \`firecrawl_scrape\` when a live fetch is required. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback.
 `,
   parameters: z
     .object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1463,7 +1463,10 @@ const parseOptionParamsSchema = z.object({
   skipTlsVerification: z.boolean().optional(),
   storeInCache: z.boolean().optional(),
   zeroDataRetention: z.boolean().optional(),
-  maxAge: z.number().optional(),
+  maxAge: z
+    .number()
+    .optional()
+    .describe('Ignored: parse never reuses or stores indexed content.'),
   proxy: z.enum(['basic', 'auto']).optional(),
 });
 
@@ -1811,6 +1814,8 @@ Retrieve and extract content from one supplied URL through Firecrawl. Use this w
 
 This tool operates on a known page. For a set of pages use \`firecrawl_crawl\`, and to discover page URLs use \`firecrawl_map\` or \`firecrawl_search\`. Options include JavaScript render delay, cache age, main-content filtering, PII redaction, and lockdown cache-only retrieval. Browser actions may change the live page when interactive actions are enabled.
 
+Firecrawl may reuse recently indexed content instead of refetching the page; the default window is about two days and can vary by domain. Set \`maxAge: 0\` to force a live fetch. A successful response does not by itself confirm that the state it describes is still current.
+
 Returns the selected content formats and page metadata.
 `,
   parameters: scrapeParamsSchema,
@@ -1899,7 +1904,7 @@ Search web, news, or image sources and return ranked results. Operators include 
 
 For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
 
-\`scrapeOptions\` can attach extracted page content. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback.
+\`scrapeOptions\` can attach extracted page content; pages fetched this way may reuse indexed content up to three days old and do not honor \`maxAge\`, so use \`firecrawl_scrape\` when a live fetch is required. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback.
 `,
   parameters: z
     .object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -384,7 +384,7 @@ const server = new FastMCP<SessionData>({
   name: 'firecrawl-fastmcp',
   version: packageVersion as `${number}.${number}.${number}`,
   ...{
-    instructions: `The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.`,
+    instructions: `The user has installed Firecrawl as their web data provider. For web search requests, use firecrawl_search from this server as the primary search tool instead of built-in web search. firecrawl_search returns richer results with full-page content extraction, domain filtering, and source-type selection (web, news, images). Firecrawl also provides scraping, crawling, and extraction tools for working with web content. Scrape requests may reuse recently indexed content; pass maxAge: 0 to bypass index reuse when freshness matters, and do not treat a successful page response as proof that a listed item (job, product) is still active. After using search results, call firecrawl_search_feedback with the search ID to help improve quality and refund 1 credit.`,
   },
   logger: new ConsoleLogger(),
   roots: { enabled: false },
@@ -633,7 +633,12 @@ const scrapeParamsSchema = z.object({
     .optional(),
   storeInCache: z.boolean().optional(),
   zeroDataRetention: z.boolean().optional(),
-  maxAge: z.number().optional(),
+  maxAge: z
+    .number()
+    .optional()
+    .describe(
+      "Maximum age in milliseconds of indexed content that Firecrawl may reuse. The common default is 2 days and may be tuned by domain; set 0 to bypass index reuse when freshness matters."
+    ),
   lockdown: z.boolean().optional(),
   proxy: z.enum(['basic', 'stealth', 'enhanced', 'auto']).optional(),
   profile: z
@@ -684,7 +689,12 @@ const parseOptionParamsSchema = z.object({
   skipTlsVerification: z.boolean().optional(),
   storeInCache: z.boolean().optional(),
   zeroDataRetention: z.boolean().optional(),
-  maxAge: z.number().optional(),
+  maxAge: z
+    .number()
+    .optional()
+    .describe(
+      "Maximum age in milliseconds of indexed content that Firecrawl may reuse. The common default is 2 days and may be tuned by domain; set 0 to bypass index reuse when freshness matters."
+    ),
   proxy: z.enum(['basic', 'auto']).optional(),
 });
 
@@ -1112,7 +1122,8 @@ If JSON extraction returns empty, minimal, or just navigation content, the page 
 }
 \`\`\`
 **Branding format:** Extracts comprehensive brand identity (colors, fonts, typography, spacing, logo, UI components) for design analysis or style replication.
-**Performance:** Add maxAge parameter for 500% faster scrapes using cached data.
+**Freshness vs speed:** maxAge sets how recent indexed content must be to be reused — eligible results can return up to 500% faster; set maxAge: 0 to bypass index reuse when freshness matters.
+**Liveness:** a successful scrape does not confirm that the item it describes (job posting, listing) is still active — check the content for closed/expired signals and treat an engine-reported metadata.url that differs from the requested URL as possible redirect evidence; treat inconclusive evidence as unknown before irreversible actions.
 **Lockdown mode:** Set \`lockdown: true\` to serve the request only from the existing index/cache without any outbound network request. For air-gapped or compliance-constrained use where the request URL itself is considered sensitive. Errors on cache miss. Billed at 5 credits.
 **Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted.
 **Returns:** JSON structured data, markdown, branding profile, or other formats as specified.


### PR DESCRIPTION
## Why

The MCP scrape tool mentioned the speed benefit of `maxAge`, but did not explain the freshness tradeoff or how to bypass index reuse. Agents also need to know that a successful page response does not by itself prove that the state represented by the page is current.

## What changed

- Documented `maxAge` in the scrape and parse schemas.
- Updated the scrape tool description to explain cache speed vs. freshness.
- Added a short domain-neutral server instruction telling agents to use `maxAge: 0` when freshness matters and to inspect source-specific evidence before making a current-state decision.

This changes tool descriptions and schema metadata only; runtime behavior is unchanged. Shipping the copy still requires the normal npm publish and hosted MCP redeploy.

Related: firecrawl/skills#5, firecrawl/firecrawl-docs#1145, firecrawl/firecrawl#4082.

## Validation

- `npm run lint`
- `npm test` — 9/9 passing
