### PR TITLE
feat(mcp): add primary OAuth-only search profile

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env sh
 set -e
 
+# The full identity keeps /v2/mcp-search on its in-process companion (:3001).
+# A dedicated primary search pod owns the same public path on the main app
+# (:3000). Render only this fixed upstream token; do not interpolate arbitrary
+# environment values into nginx configuration.
+SEARCH_UPSTREAM=app_search
+if [ "${FASTMCP_ENDPOINT:-/v2/mcp}" = "/v2/mcp-search" ]; then
+  SEARCH_UPSTREAM=app
+fi
+sed "s/__MCP_SEARCH_UPSTREAM__/${SEARCH_UPSTREAM}/g" \
+  /etc/nginx/nginx.conf > /tmp/nginx.conf
+mv /tmp/nginx.conf /etc/nginx/nginx.conf
+
 # Start Node app in background
 node dist/index.js &
 APP_PID=$!
@@ -9,5 +21,4 @@ APP_PID=$!
 nginx -g 'daemon off;'
 
 wait $APP_PID
-
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -17,7 +17,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_pass http://app_search;
+      proxy_pass http://__MCP_SEARCH_UPSTREAM__;
     }
 
     # OAuth discovery documents (RFC 8414 / RFC 9728) must reach the app with the
@@ -80,8 +80,9 @@ http {
       proxy_pass http://app;
     }
 
-    # Search surface, header-based: exactly /v2/mcp-search (or a subpath), served
-    # by the second instance on :3001. The (?:/|$) boundary keeps it from
+    # Search surface, header-based: exactly /v2/mcp-search (or a subpath). It is
+    # served by the in-process companion on full pods and by the primary app on
+    # a dedicated search pod. The (?:/|$) boundary keeps it from
     # swallowing unrelated paths like /v2/mcp-searchXYZ. Placed before the
     # generic /v(1|2)/(.*) regex so it wins (first matching regex wins). Proxied
     # verbatim because the instance serves the /v2/mcp-search path directly.
@@ -95,7 +96,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_pass http://app_search;
+      proxy_pass http://__MCP_SEARCH_UPSTREAM__;
     }
 
     # Search surface, key-in-path: /{apiKey}/v2/mcp-search. Mirrors the legacy
@@ -115,7 +116,7 @@ http {
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
       rewrite ^/[^/]+(/v2/mcp-search.*)$ $1 break;
-      proxy_pass http://app_search;
+      proxy_pass http://__MCP_SEARCH_UPSTREAM__;
     }
 
     # Deprecated key-in-path MCP compatibility for the full identity. Never log
@@ -225,6 +226,19 @@ http {
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app/health;
+    }
+
+    # Never let the catch-all documentation redirect satisfy a Kubernetes
+    # readiness probe. This route reaches the Node application's profile-aware
+    # readiness check directly through nginx.
+    location = /ready {
+      proxy_buffering off;
+      proxy_read_timeout 5s;
+      proxy_send_timeout 5s;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_pass http://app/ready;
     }
 
     location / {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,12 @@ type ServerProfile = {
   toolAllowlist?: Set<string>;
   /** Allow the keyless free-tier fallback (no credential required). */
   allowKeyless: boolean;
+  /** Whether ordinary Firecrawl API keys are accepted for this identity. */
+  acceptApiKeys: boolean;
+  /** Require a managed hosted-MCP OAuth grant, never a legacy/general token. */
+  requireManagedOAuth?: boolean;
+  /** Whether this process's primary listener owns this profile. */
+  primary?: boolean;
   /** Accept tokens minted for the legacy /v2/mcp resource during migration. */
   acceptLegacyAudience?: boolean;
 };
@@ -114,8 +120,13 @@ function isFirecrawlApiKey(token: string): boolean {
 }
 
 function requestShouldReceiveOAuthChallenge(
-  request: MCPAuthRequest | undefined
+  request: MCPAuthRequest | undefined,
+  profile: ServerProfile
 ): boolean {
+  // OAuth-only profiles must challenge API-key and key-in-path attempts too;
+  // otherwise FastMCP would return a generic error instead of the resource's
+  // reconnectable OAuth challenge.
+  if (!profile.acceptApiKeys) return true;
   if (!request?.headers) return true;
   const headerApiKey = normalizeHeader(
     request.headers['x-firecrawl-api-key'] ?? request.headers['x-api-key']
@@ -162,11 +173,17 @@ function getMcpResourceUrl(): string {
   );
 }
 
-function getPrimaryEndpoint(): '/v2/mcp' | '/v2/mcp-oauth' {
+function getPrimaryEndpoint(): '/v2/mcp' | '/v2/mcp-oauth' | '/v2/mcp-search' {
   const endpoint = normalizeHeader(process.env.FASTMCP_ENDPOINT) ?? '/v2/mcp';
-  if (endpoint === '/v2/mcp' || endpoint === '/v2/mcp-oauth') return endpoint;
+  if (
+    endpoint === '/v2/mcp' ||
+    endpoint === '/v2/mcp-oauth' ||
+    endpoint === '/v2/mcp-search'
+  ) {
+    return endpoint;
+  }
   throw new Error(
-    `Unsupported FASTMCP_ENDPOINT: ${endpoint}. Expected /v2/mcp or /v2/mcp-oauth.`
+    `Unsupported FASTMCP_ENDPOINT: ${endpoint}. Expected /v2/mcp, /v2/mcp-oauth, or /v2/mcp-search.`
   );
 }
 
@@ -361,6 +378,11 @@ async function resolveCredentialFromHeaders(
   );
   const token = headerApiKey ?? bearer;
   if (!token) return undefined;
+  if (!profile.acceptApiKeys && !isFirecrawlOAuthAccessToken(token)) {
+    throw new Error(
+      `OAuth access token required for the Firecrawl MCP resource ${profile.endpoint}`
+    );
+  }
   if (!isFirecrawlOAuthAccessToken(token) && !isFirecrawlApiKey(token)) {
     return { invalid: true };
   }
@@ -396,6 +418,12 @@ async function resolveCredentialFromHeaders(
       : profile.resourceUrl;
   if (!audienceMatchesResource(data.aud, expectedAudience)) {
     throw new Error('OAuth token audience does not match this resource');
+  }
+  if (
+    profile.requireManagedOAuth &&
+    data.credential_purpose !== 'hosted_mcp_oauth'
+  ) {
+    throw new Error('OAuth token is not a managed Firecrawl MCP credential');
   }
   if (data.credential_purpose === 'hosted_mcp_oauth') {
     requireDelegatedCredentialSigning();
@@ -433,6 +461,11 @@ async function authenticateRequest(
   if (process.env.CLOUD_SERVICE === 'true') {
     if (!headerCred && !managedCred) {
       if (resolved?.invalid) {
+        if (!profile.acceptApiKeys) {
+          throw new Error(
+            `OAuth access token required for the Firecrawl MCP resource ${profile.endpoint}`
+          );
+        }
         return { authType: 'none', credentialError: 'CREDENTIAL_INVALID' };
       }
       if (profile.allowKeyless) {
@@ -488,6 +521,59 @@ async function authenticateRequest(
   return managedCred ? setManagedOAuthApiKey(session, managedCred) : session;
 }
 
+type SearchCompanionAuthMode = 'oauth' | 'api-key' | 'none';
+
+function searchCompanionAuthMode(
+  request?: MCPAuthRequest,
+  session?: SessionData
+): SearchCompanionAuthMode {
+  if (session?.authType === 'oauth') return 'oauth';
+  if (session?.authType === 'api-key') return 'api-key';
+  // Mirror resolveCredentialFromHeaders precedence: explicit API-key headers
+  // win over Authorization when both are present.
+  const headerApiKey = normalizeHeader(
+    request?.headers?.['x-firecrawl-api-key'] ?? request?.headers?.['x-api-key']
+  );
+  if (headerApiKey) return 'api-key';
+  const bearer = request?.headers ? extractBearerToken(request.headers) : undefined;
+  if (bearer?.startsWith('fco_')) return 'oauth';
+  if (bearer) return 'api-key';
+  return 'none';
+}
+
+/**
+ * Additive, intentionally low-cardinality companion traffic telemetry. This
+ * is the only reliable way to establish whether the live companion is still
+ * serving API-key consumers before its explicit OAuth-only cutover. Do not add
+ * identifiers, credentials, request URLs, user agents, or hashes here.
+ */
+function emitSearchCompanionAuthTelemetry(
+  profile: ServerProfile,
+  request: MCPAuthRequest | undefined,
+  outcome: 'accepted' | 'rejected',
+  session?: SessionData
+): void {
+  if (
+    process.env.CLOUD_SERVICE !== 'true' ||
+    profile.id !== 'search' ||
+    profile.primary === true
+  ) {
+    return;
+  }
+  console.log(
+    '[MCP_SEARCH_AUTH]',
+    JSON.stringify({
+      auth_mode: searchCompanionAuthMode(request, session),
+      outcome,
+      profile: 'companion',
+      // Unique only to this telemetry record; it is not a cross-service
+      // correlation ID and does not accept client-controlled identifiers.
+      event_id: randomUUID(),
+      route: DEFAULT_MCP_SEARCH_ENDPOINT,
+    })
+  );
+}
+
 /**
  * Builds the `authenticate` hook for one profile. FastMCP runs it on every
  * request (including `tools/list`), so a rejection here yields a 401 with the
@@ -501,28 +587,39 @@ function makeAuthenticate(profile: ServerProfile) {
       return request[authResultByRequest];
     }
 
-    const authResult = authenticateRequest(request, profile).catch((error) => {
-      if (error instanceof CredentialValidationUnavailableError) {
-        throw new Response(
-          JSON.stringify({
-            error: 'temporarily_unavailable',
-            error_description: error.message,
-          }),
-          {
-            headers: { 'Content-Type': 'application/json' },
-            status: 503,
-          }
+    const authResult = authenticateRequest(request, profile)
+      .then((session) => {
+        emitSearchCompanionAuthTelemetry(
+          profile,
+          request,
+          session.credentialError ? 'rejected' : 'accepted',
+          session
         );
-      }
-      const shouldChallenge = requestShouldReceiveOAuthChallenge(request);
-      const oauthChallenge = shouldChallenge
-        ? createOAuthChallengeResponse(error, profile)
-        : undefined;
-      if (oauthChallenge) {
-        throw oauthChallenge;
-      }
-      throw error;
-    });
+        return session;
+      })
+      .catch((error) => {
+        emitSearchCompanionAuthTelemetry(profile, request, 'rejected');
+        if (error instanceof CredentialValidationUnavailableError) {
+          throw new Response(
+            JSON.stringify({
+              error: 'temporarily_unavailable',
+              error_description: error.message,
+            }),
+            {
+              headers: { 'Content-Type': 'application/json' },
+              status: 503,
+            }
+          );
+        }
+        const shouldChallenge = requestShouldReceiveOAuthChallenge(request, profile);
+        const oauthChallenge = shouldChallenge
+          ? createOAuthChallengeResponse(error, profile)
+          : undefined;
+        if (oauthChallenge) {
+          throw oauthChallenge;
+        }
+        throw error;
+      });
 
     if (request) {
       request[authResultByRequest] = authResult;
@@ -692,22 +789,48 @@ function makeFullProfile(): ServerProfile {
     endpoint: account ? '/v2/mcp-oauth' : undefined,
     port: Number(process.env.PORT || 3000),
     allowKeyless: !account,
+    acceptApiKeys: true,
     acceptLegacyAudience:
       account && process.env.MCP_OAUTH_ACCEPT_LEGACY_V2_MCP_AUD !== 'false',
+    primary: true,
   };
 }
 
-function makeSearchProfile(): ServerProfile {
+function searchOAuthOnly(): boolean {
+  return process.env.FIRECRAWL_MCP_SEARCH_OAUTH_ONLY === 'true';
+}
+
+function makeSearchProfile({ primary = false }: { primary?: boolean } = {}): ServerProfile {
+  const oauthOnly = searchOAuthOnly();
+  if (primary && !oauthOnly) {
+    throw new Error(
+      'FASTMCP_ENDPOINT=/v2/mcp-search requires FIRECRAWL_MCP_SEARCH_OAUTH_ONLY=true'
+    );
+  }
   return {
     id: 'search',
     resourceName: 'Firecrawl Search',
     instructions: SEARCH_PROFILE_INSTRUCTIONS,
     resourceUrl: getSearchMcpResourceUrl(),
-    endpoint: getSearchMcpEndpoint(),
-    port: Number(process.env.FIRECRAWL_MCP_SEARCH_PORT || 3001),
+    endpoint: primary ? DEFAULT_MCP_SEARCH_ENDPOINT : getSearchMcpEndpoint(),
+    port: primary
+      ? Number(process.env.PORT || 3000)
+      : Number(process.env.FIRECRAWL_MCP_SEARCH_PORT || 3001),
     toolAllowlist: SEARCH_PROFILE_TOOLS,
     allowKeyless: false,
+    // This is deliberately default-false because the image auto-deploys: the
+    // existing in-process companion remains API-key compatible unless its
+    // deployment explicitly enables the same profile flag used by primary.
+    acceptApiKeys: !oauthOnly,
+    requireManagedOAuth: oauthOnly,
+    primary,
   };
+}
+
+function makePrimaryProfile(): ServerProfile {
+  return getPrimaryEndpoint() === '/v2/mcp-search'
+    ? makeSearchProfile({ primary: true })
+    : makeFullProfile();
 }
 
 function createServer(profile: ServerProfile): FastMCP<SessionData> {
@@ -738,7 +861,7 @@ function createServer(profile: ServerProfile): FastMCP<SessionData> {
   });
 }
 
-const primaryProfile = makeFullProfile();
+const primaryProfile = makePrimaryProfile();
 const server = createServer(primaryProfile);
 type RegisteredTool = Parameters<typeof server.addTool>[0];
 
@@ -871,7 +994,24 @@ function guardHostedTool(
 
 const addTool = server.addTool.bind(server);
 server.addTool = ((tool: RegisteredTool) => {
-  addTool(guardHostedTool(tool, { logActions: true }));
+  // A dedicated search process registers through the same module-level tool
+  // setup as full MCP. Filter at the server boundary so an accidental future
+  // registration cannot widen its frozen public contract.
+  if (
+    primaryProfile.toolAllowlist &&
+    !primaryProfile.toolAllowlist.has(tool.name)
+  ) {
+    return;
+  }
+  // The module registers the full `firecrawl_search` before startup. A primary
+  // search profile must instead receive the strict marketplace variant below:
+  // it has no scrapeOptions and no instructions referring to the excluded
+  // feedback tool. Keep the name filter here so the full registration cannot
+  // leak into the frozen six-tool surface.
+  if (primaryProfile.id === 'search' && tool.name === 'firecrawl_search') {
+    return;
+  }
+  addTool(guardHostedTool(tool, { logActions: primaryProfile.id !== 'search' }));
 }) as typeof server.addTool;
 
 if (openAiAppsChallengeToken) {
@@ -886,20 +1026,37 @@ server.getApp().get('/ready', (context) => {
   if (process.env.CLOUD_SERVICE !== 'true') {
     return context.json({ ok: true }, 200);
   }
-  const missing = [
-    'FIRECRAWL_API_URL',
-    'FIRECRAWL_OAUTH_INTROSPECT_SECRET',
-    'FIRECRAWL_MCP_ACTION_LOG_SECRET',
-    'KEYLESS_PROXY_SECRET',
-    'MCP_DELEGATED_CREDENTIAL_SECRET',
-  ].filter((name) => !normalizeHeader(process.env[name]));
+  const searchPrimary = primaryProfile.id === 'search';
+  const required = searchPrimary
+    ? [
+        // A search primary only serves account OAuth. It must be able to
+        // introspect and sign the short-lived fcmcp_ credential, but it never
+        // uses the keyless eligibility proxy or action-log ingestion secret.
+        'FIRECRAWL_API_URL',
+        'FIRECRAWL_OAUTH_INTROSPECT_SECRET',
+        'MCP_DELEGATED_CREDENTIAL_SECRET',
+      ]
+    : [
+        'FIRECRAWL_API_URL',
+        'FIRECRAWL_OAUTH_INTROSPECT_SECRET',
+        'FIRECRAWL_MCP_ACTION_LOG_SECRET',
+        'KEYLESS_PROXY_SECRET',
+        'MCP_DELEGATED_CREDENTIAL_SECRET',
+      ];
+  const missing = required.filter((name) => !normalizeHeader(process.env[name]));
   const configuredEndpoint = getPrimaryEndpoint();
-  if (
-    withoutTrailingSlash(primaryProfile.resourceUrl).endsWith(
-      configuredEndpoint
-    ) === false
-  ) {
-    missing.push('FIRECRAWL_MCP_RESOURCE_URL (endpoint mismatch)');
+  const resourceMatchesEndpoint = searchPrimary
+    ? withoutTrailingSlash(primaryProfile.resourceUrl) ===
+      DEFAULT_MCP_SEARCH_RESOURCE_URL
+    : withoutTrailingSlash(primaryProfile.resourceUrl).endsWith(
+        configuredEndpoint
+      );
+  if (!resourceMatchesEndpoint) {
+    missing.push(
+      searchPrimary
+        ? 'FIRECRAWL_MCP_SEARCH_RESOURCE_URL (endpoint mismatch)'
+        : 'FIRECRAWL_MCP_RESOURCE_URL (endpoint mismatch)'
+    );
   }
   return missing.length
     ? context.json({ ok: false, missing }, 503)
@@ -3205,6 +3362,20 @@ if (
 
 registerMonitorTools(server);
 registerResearchTools(server, getClient);
+
+if (primaryProfile.id === 'search') {
+  // The strict marketplace search tool intentionally replaces the full
+  // surface's same-named registration above. Register through the original
+  // bound method so the name-level guard cannot suppress this replacement.
+  const primarySearchRegistrar: ToolRegistrar = {
+    addTool: ((tool: { name: string }) => {
+      if (primaryProfile.toolAllowlist?.has(tool.name)) {
+        addTool(guardHostedTool(tool as RegisteredTool, { logActions: false }));
+      }
+    }) as FastMCP<SessionData>['addTool'],
+  };
+  registerMarketplaceSearchTool(primarySearchRegistrar, getClient);
+}
 
 await server.start(args);
 

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -199,8 +199,12 @@ async function startHostedServer(t, extraEnv = {}) {
     ...extraEnv,
   });
   let stderr = '';
+  let stdout = '';
   child.stderr.on('data', (chunk) => {
     stderr += chunk;
+  });
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
   });
   t.after(() => stopChild(child));
   await waitForHealth(searchPort, child);
@@ -210,6 +214,40 @@ async function startHostedServer(t, extraEnv = {}) {
     searchPort,
     issuerUrl: extraEnv.FIRECRAWL_OAUTH_ISSUER ?? defaultBackend.url,
     getStderr: () => stderr,
+    getStdout: () => stdout,
+  };
+}
+
+// The dedicated search deployment runs the search profile as its primary
+// listener on :3000. Unlike the live companion, it deliberately has no
+// KEYLESS_PROXY_SECRET and rejects every API-key transport.
+async function startPrimarySearchServer(t, extraEnv = {}) {
+  const defaultBackend = await startFakeBackend({ introspectionAud: SEARCH_RESOURCE });
+  t.after(() => defaultBackend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    HTTP_STREAMABLE_SERVER: 'true',
+    FASTMCP_ENDPOINT: SEARCH_ENDPOINT,
+    FIRECRAWL_API_URL: defaultBackend.url,
+    FIRECRAWL_MCP_SEARCH_RESOURCE_URL: SEARCH_RESOURCE,
+    FIRECRAWL_MCP_SEARCH_OAUTH_ONLY: 'true',
+    FIRECRAWL_OAUTH_ISSUER: defaultBackend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    PORT: String(port),
+    ...extraEnv,
+  });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+  return {
+    child,
+    getStderr: () => stderr,
+    issuerUrl: extraEnv.FIRECRAWL_OAUTH_ISSUER ?? defaultBackend.url,
+    port,
   };
 }
 
@@ -225,7 +263,7 @@ function jsonRpc(port, endpoint, { id, method, params = {}, headers = {} }) {
   });
 }
 
-async function listTools(port, endpoint, headers) {
+async function listToolDefinitions(port, endpoint, headers) {
   const res = await jsonRpc(port, endpoint, {
     id: 1,
     method: 'tools/list',
@@ -233,7 +271,12 @@ async function listTools(port, endpoint, headers) {
   });
   assert.equal(res.status, 200, `tools/list returned ${res.status}`);
   const message = parseSseJson(await res.text());
-  return message.result.tools.map((tool) => tool.name);
+  return message.result.tools;
+}
+
+async function listTools(port, endpoint, headers) {
+  const tools = await listToolDefinitions(port, endpoint, headers);
+  return tools.map((tool) => tool.name);
 }
 
 test('search surface lists exactly the six read-only tools', async (t) => {
@@ -512,4 +555,236 @@ test('full surface still exposes its complete tool set alongside the search surf
     resource_name: 'Firecrawl MCP',
     scopes_supported: ['firecrawl:global'],
   });
+});
+
+test('primary search profile is OAuth-only, six-tool frozen, and ready without keyless configuration', async (t) => {
+  const { port, issuerUrl } = await startPrimarySearchServer(t);
+
+  const ready = await fetch(`http://127.0.0.1:${port}/ready`);
+  assert.equal(ready.status, 200);
+  assert.deepEqual(await ready.json(), { ok: true });
+
+  const anonymous = await jsonRpc(port, SEARCH_ENDPOINT, {
+    id: 10,
+    method: 'tools/list',
+  });
+  assert.equal(anonymous.status, 401);
+  assert.match(
+    anonymous.headers.get('www-authenticate') ?? '',
+    /oauth-protected-resource\/v2\/mcp-search/
+  );
+
+  for (const headers of [
+    { authorization: 'Bearer fc-primary-search-api-key' },
+    { 'x-api-key': 'fc-primary-search-api-key' },
+    { 'x-firecrawl-api-key': 'fc-primary-search-api-key' },
+  ]) {
+    const response = await jsonRpc(port, SEARCH_ENDPOINT, {
+      id: JSON.stringify(headers),
+      method: 'tools/list',
+      headers,
+    });
+    assert.equal(response.status, 401, JSON.stringify(headers));
+    assert.match(response.headers.get('www-authenticate') ?? '', /Bearer /);
+  }
+
+  const prm = await fetch(
+    `http://127.0.0.1:${port}/.well-known/oauth-protected-resource${SEARCH_ENDPOINT}`
+  );
+  assert.equal(prm.status, 200);
+  assert.deepEqual(await prm.json(), {
+    authorization_servers: [issuerUrl],
+    bearer_methods_supported: ['header'],
+    resource: SEARCH_RESOURCE,
+    resource_name: 'Firecrawl Search',
+    scopes_supported: ['firecrawl:global'],
+  });
+
+  const names = await listTools(port, SEARCH_ENDPOINT, {
+    authorization: 'Bearer fco_primary_search_resource_token',
+  });
+  assert.deepEqual([...names].sort(), [...SEARCH_TOOLS].sort());
+});
+
+test('primary search readiness requires the exact canonical resource origin', async (t) => {
+  const { port } = await startPrimarySearchServer(t, {
+    FIRECRAWL_MCP_SEARCH_RESOURCE_URL: `https://example.invalid${SEARCH_ENDPOINT}`,
+  });
+
+  const ready = await fetch(`http://127.0.0.1:${port}/ready`);
+  assert.equal(ready.status, 503);
+  assert.deepEqual(await ready.json(), {
+    ok: false,
+    missing: ['FIRECRAWL_MCP_SEARCH_RESOURCE_URL (endpoint mismatch)'],
+  });
+});
+
+test('primary search profile uses the strict marketplace search tool, not the full search variant', async (t) => {
+  const { port } = await startPrimarySearchServer(t);
+  const headers = { authorization: 'Bearer fco_primary_strict_search' };
+  const tools = await listToolDefinitions(port, SEARCH_ENDPOINT, headers);
+  const search = tools.find((tool) => tool.name === 'firecrawl_search');
+  assert.ok(search, 'primary profile must register firecrawl_search');
+  assert.doesNotMatch(JSON.stringify(search.inputSchema), /scrapeOptions/);
+  assert.doesNotMatch(search.description ?? '', /search_feedback|refund/i);
+
+  const response = await jsonRpc(port, SEARCH_ENDPOINT, {
+    id: 13,
+    method: 'tools/call',
+    params: {
+      arguments: {
+        query: 'strict marketplace search',
+        scrapeOptions: { formats: ['markdown'] },
+      },
+      name: 'firecrawl_search',
+    },
+    headers,
+  });
+  assert.equal(response.status, 200);
+  const message = parseSseJson(await response.text());
+  assert.equal(
+    Boolean(message.error) || message.result?.isError === true,
+    true,
+    JSON.stringify(message)
+  );
+});
+
+test('primary search profile fails closed unless the canonical OAuth-only flag is enabled', async (t) => {
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    HTTP_STREAMABLE_SERVER: 'true',
+    FASTMCP_ENDPOINT: SEARCH_ENDPOINT,
+    FIRECRAWL_API_URL: 'http://127.0.0.1:9',
+    FIRECRAWL_MCP_SEARCH_RESOURCE_URL: SEARCH_RESOURCE,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    PORT: String(port),
+  });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    delay(2_000).then(() => assert.fail('primary search profile unexpectedly started')),
+  ]);
+  assert.notEqual(child.exitCode, 0);
+  assert.match(stderr, /FIRECRAWL_MCP_SEARCH_OAUTH_ONLY=true/);
+});
+
+test('primary search profile rejects legacy /v2/mcp audience and requires the delegated signing secret', async (t) => {
+  const legacyBackend = await startFakeBackend({
+    introspectionAud: 'https://mcp.firecrawl.dev/v2/mcp',
+  });
+  t.after(() => legacyBackend.close());
+  const { port } = await startPrimarySearchServer(t, {
+    FIRECRAWL_API_URL: legacyBackend.url,
+    FIRECRAWL_OAUTH_ISSUER: legacyBackend.url,
+  });
+
+  const wrongAudience = await jsonRpc(port, SEARCH_ENDPOINT, {
+    id: 11,
+    method: 'tools/list',
+    headers: { authorization: 'Bearer fco_legacy_audience' },
+  });
+  assert.equal(wrongAudience.status, 401);
+
+  // A separate process proves readiness is profile-specific: search needs the
+  // fcmcp_ signer but intentionally does not require KEYLESS_PROXY_SECRET.
+  const unavailablePort = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    HTTP_STREAMABLE_SERVER: 'true',
+    FASTMCP_ENDPOINT: SEARCH_ENDPOINT,
+    FIRECRAWL_API_URL: legacyBackend.url,
+    FIRECRAWL_MCP_SEARCH_RESOURCE_URL: SEARCH_RESOURCE,
+    FIRECRAWL_MCP_SEARCH_OAUTH_ONLY: 'true',
+    FIRECRAWL_OAUTH_ISSUER: legacyBackend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    MCP_DELEGATED_CREDENTIAL_SECRET: '',
+    PORT: String(unavailablePort),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(unavailablePort, child);
+  const ready = await fetch(`http://127.0.0.1:${unavailablePort}/ready`);
+  assert.equal(ready.status, 503);
+  assert.deepEqual(await ready.json(), {
+    missing: ['MCP_DELEGATED_CREDENTIAL_SECRET'],
+    ok: false,
+  });
+});
+
+test('companion stays API-key compatible by default and only becomes OAuth-only behind its explicit flag', async (t) => {
+  const backend = await startFakeBackend({ introspectionAud: SEARCH_RESOURCE });
+  t.after(() => backend.close());
+  const { searchPort } = await startHostedServer(t, {
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_MCP_SEARCH_OAUTH_ONLY: 'true',
+  });
+
+  const apiKey = await jsonRpc(searchPort, SEARCH_ENDPOINT, {
+    id: 12,
+    method: 'tools/list',
+    headers: { authorization: 'Bearer fc-companion-api-key' },
+  });
+  assert.equal(apiKey.status, 401);
+
+  const names = await listTools(searchPort, SEARCH_ENDPOINT, {
+    authorization: 'Bearer fco_companion_search_resource_token',
+  });
+  assert.deepEqual([...names].sort(), [...SEARCH_TOOLS].sort());
+});
+
+test('companion emits sanitized auth-mode telemetry without credential material', async (t) => {
+  const { searchPort, getStdout } = await startHostedServer(t);
+  await listTools(searchPort, SEARCH_ENDPOINT, {
+    authorization: 'Bearer fc-telemetry-must-not-appear',
+  });
+  await delay(25);
+  const logs = getStdout();
+  const eventLine = logs
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('[MCP_SEARCH_AUTH] '));
+  assert.ok(eventLine, logs);
+  const event = JSON.parse(eventLine.slice('[MCP_SEARCH_AUTH] '.length));
+  assert.deepEqual(event, {
+    auth_mode: 'api-key',
+    outcome: 'accepted',
+    profile: 'companion',
+    event_id: event.event_id,
+    route: SEARCH_ENDPOINT,
+  });
+  assert.match(
+    event.event_id,
+    /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i
+  );
+  assert.doesNotMatch(logs, /fc-telemetry-must-not-appear/);
+  assert.doesNotMatch(logs, /authorization/i);
+});
+
+test('companion telemetry follows credential precedence and rejects invalid credentials', async (t) => {
+  const { searchPort, getStdout } = await startHostedServer(t);
+
+  await listTools(searchPort, SEARCH_ENDPOINT, {
+    authorization: 'Bearer fco_secondary-credential',
+    'x-api-key': 'fc-primary-credential',
+  });
+  await listTools(searchPort, SEARCH_ENDPOINT, {
+    authorization: 'Bearer fc-invalid-credential',
+  });
+  await delay(25);
+
+  const events = getStdout()
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('[MCP_SEARCH_AUTH] '))
+    .map((line) => JSON.parse(line.slice('[MCP_SEARCH_AUTH] '.length)));
+  assert.deepEqual(
+    events.map(({ auth_mode, outcome }) => ({ auth_mode, outcome })),
+    [
+      { auth_mode: 'api-key', outcome: 'accepted' },
+      { auth_mode: 'api-key', outcome: 'rejected' },
+    ]
+  );
+  assert.doesNotMatch(getStdout(), /fc-primary-credential|fco_secondary-credential/);
 });

--- a/tests/nginx-config.test.mjs
+++ b/tests/nginx-config.test.mjs
@@ -65,3 +65,19 @@ test('legacy MCP aliases stay bound to the full identity', () => {
     assert.doesNotMatch(body, /mcp-oauth/);
   }
 });
+
+test('search routes are rendered to a fixed upstream and readiness reaches Node', async () => {
+  assert.match(config, /proxy_pass http:\/\/__MCP_SEARCH_UPSTREAM__;/);
+  const entrypoint = await readFile(
+    new URL('../docker/entrypoint.sh', import.meta.url),
+    'utf8'
+  );
+  assert.match(entrypoint, /FASTMCP_ENDPOINT:-\/v2\/mcp/);
+  assert.match(entrypoint, /\[ "\$\{FASTMCP_ENDPOINT:-\/v2\/mcp\}" = "\/v2\/mcp-search" \]/);
+  assert.match(entrypoint, /SEARCH_UPSTREAM=app_search/);
+  assert.match(entrypoint, /SEARCH_UPSTREAM=app/);
+  assert.match(entrypoint, /s\/__MCP_SEARCH_UPSTREAM__\/\$\{SEARCH_UPSTREAM\}\/g/);
+
+  const ready = locationBody('location = /ready');
+  assert.match(ready, /proxy_pass http:\/\/app\/ready;/);
+});


### PR DESCRIPTION
## Summary
- adds `/v2/mcp-search` as a primary hosted profile with its own protected resource, exact six-tool allowlist, managed OAuth-only authentication, and audience isolation
- registers the same strict marketplace `firecrawl_search` variant used by the shipped companion (no `scrapeOptions`, no excluded feedback/refund instructions), preserving the companion's existing `enterprise` option
- establishes `FIRECRAWL_MCP_SEARCH_OAUTH_ONLY=true` as the single per-profile credential-policy flag: required fail-closed for a primary search process; default-false preserves the existing companion's API-key + OAuth behavior; enabling it later makes that companion OAuth-only
- adds sanitized, low-cardinality companion auth telemetry with route, profile, resolved auth mode, outcome, and an event ID; it follows actual credential precedence, treats invalid-credential recovery as rejected, and never records credentials, headers, hashes, user agents, or client identifiers
- makes nginx choose the companion on full pods and the primary Node app on search-profile pods; `/ready` now proxies to Node instead of the catch-all redirect
- makes readiness profile-aware: primary search requires API URL, introspection secret, and `MCP_DELEGATED_CREDENTIAL_SECRET`, but not `KEYLESS_PROXY_SECRET`

## Safety
This image auto-deploys to the existing full/scalable pods. With the default `FIRECRAWL_MCP_SEARCH_OAUTH_ONLY=false`, the deployed companion remains six-tool and API-key + OAuth compatible. Primary search cannot start unless the separate deployment explicitly sets the canonical flag true.

## Validation
- `pnpm run build`
- `pnpm run lint`
- `node --test tests/mcp-search-profile.test.mjs tests/nginx-config.test.mjs` (24 passing)
- `pnpm test` (40 passing)
- Docker service-image smoke: rendered primary search nginx routing, direct `/ready` = 200, anonymous/API-key/key-in-path requests = 401, `nginx -t` successful

## Follow-ups / dependencies
- Web must enable managed search-resource handling only behind its canary gate after the DB resource migration.
- Infra must create the private search profile with `FIRECRAWL_MCP_SEARCH_OAUTH_ONLY=true`, the matching delegated-credential secret, and direct application readiness before public route cutover.
- The low-cardinality event is sufficient to prove zero accepted API-key traffic, but deliberately cannot identify consumers or separate controlled API-key probes. A non-zero usage result requires a separately approved privacy-safe migration investigation; do not use this event alone to authorize cutover.
