### PR TITLE
fix(mcp): align readiness with auth profiles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1027,22 +1027,18 @@ server.getApp().get('/ready', (context) => {
     return context.json({ ok: true }, 200);
   }
   const searchPrimary = primaryProfile.id === 'search';
-  const required = searchPrimary
-    ? [
-        // A search primary only serves account OAuth. It must be able to
-        // introspect and sign the short-lived fcmcp_ credential, but it never
-        // uses the keyless eligibility proxy or action-log ingestion secret.
-        'FIRECRAWL_API_URL',
-        'FIRECRAWL_OAUTH_INTROSPECT_SECRET',
-        'MCP_DELEGATED_CREDENTIAL_SECRET',
-      ]
-    : [
-        'FIRECRAWL_API_URL',
-        'FIRECRAWL_OAUTH_INTROSPECT_SECRET',
-        'FIRECRAWL_MCP_ACTION_LOG_SECRET',
-        'KEYLESS_PROXY_SECRET',
-        'MCP_DELEGATED_CREDENTIAL_SECRET',
-      ];
+  // Readiness covers only dependencies that can prevent this profile from
+  // serving authenticated requests. Account and search identities never take
+  // the keyless path; action logging is intentionally best-effort (see
+  // emitActionLog), so neither should make those profiles unavailable.
+  const required = [
+    'FIRECRAWL_API_URL',
+    'FIRECRAWL_OAUTH_INTROSPECT_SECRET',
+    'MCP_DELEGATED_CREDENTIAL_SECRET',
+  ];
+  if (primaryProfile.allowKeyless) {
+    required.push('KEYLESS_PROXY_SECRET');
+  }
   const missing = required.filter((name) => !normalizeHeader(process.env[name]));
   const configuredEndpoint = getPrimaryEndpoint();
   const resourceMatchesEndpoint = searchPrimary

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -824,7 +824,6 @@ test('account endpoint challenges anonymous clients and accepts API keys', async
     FIRECRAWL_OAUTH_ISSUER: backend.url,
     FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
     HTTP_STREAMABLE_SERVER: 'true',
-    KEYLESS_PROXY_SECRET: 'delegation-secret',
     PORT: String(port),
   });
   t.after(() => stopChild(child));
@@ -896,7 +895,7 @@ test('account readiness requires the managed OAuth delegation secret', async (t)
   const ready = await fetch(`http://127.0.0.1:${port}/ready`);
   assert.equal(ready.status, 503);
   assert.deepEqual(await ready.json(), {
-    missing: ['KEYLESS_PROXY_SECRET', 'MCP_DELEGATED_CREDENTIAL_SECRET'],
+    missing: ['MCP_DELEGATED_CREDENTIAL_SECRET'],
     ok: false,
   });
 });


### PR DESCRIPTION
## Problem
MCP #332 made nginx proxy `/ready` to the real application endpoint. The account-only `/v2/mcp-oauth` pods then reported 503 because their readiness check incorrectly required `KEYLESS_PROXY_SECRET`, even though they never serve the keyless path. Existing ready pods remain serving while Kubernetes holds the new revision.

## Fix
Require only the true hard dependencies for every managed profile: API URL, introspection secret, and delegated-credential signing secret. Require `KEYLESS_PROXY_SECRET` only for profiles that allow keyless traffic. Action logging remains best-effort as it is at request time.

## Regression coverage
- account profile is ready and serves its route without `KEYLESS_PROXY_SECRET`
- account profile remains unready when its delegated signing secret is absent
- full test suite covers the search primary, account, full/keyless, and nginx contracts

## Validation
- `npm run lint`
- `npm test` (40 passing)

This is a production rollback-safe readiness correction; it does not change authentication or tool-route behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787640416&installation_model_id=11126&pr_number=333&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F333&signature=1fa3d3e17cb77e43407c33e18ce71628c9582b14599731178e949c0289fbab81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes readiness checks to match each MCP auth profile so account-only pods stop returning 503. Only essential secrets are required; the keyless secret is needed only when the profile allows keyless traffic.

- Bug Fixes
  - Readiness requires only `FIRECRAWL_API_URL`, `FIRECRAWL_OAUTH_INTROSPECT_SECRET`, and `MCP_DELEGATED_CREDENTIAL_SECRET`.
  - `KEYLESS_PROXY_SECRET` is required only when `primaryProfile.allowKeyless` is true.
  - Action logging is excluded from readiness (best-effort at request time).
  - Updated smoke tests to reflect the new readiness criteria.

<sup>Written for commit 63333200a0fca0151f8645f08f0ceea8eaa5ee14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

