### PR TITLE
fix(mcp): restore hosted keyless Parse safety boundaries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { z } from 'zod';
+import { extractSinglePublicClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
 import {
@@ -1586,6 +1587,16 @@ async function executeHostedParse(
     });
   }
 
+  if (isHostedKeylessSession(session) && args.zeroDataRetention === true) {
+    const payload = {
+      ...recoveryPayload('KEYLESS_OPTION_NOT_AVAILABLE'),
+      option: 'zeroDataRetention',
+      message:
+        'Zero Data Retention is not available in anonymous keyless mode. Omit zeroDataRetention to parse with keyless access, or connect an account or configure an API key for a team where Zero Data Retention is enabled, then retry.',
+    };
+    throw new UserError(String(payload.message), payload);
+  }
+
   const options = extractParseOptions(args);
 
   if (hasFilePath && args.filePath) {
@@ -2016,10 +2027,7 @@ function resolveApiBaseUrl(): string {
 function extractClientIp(request?: {
   headers: IncomingHttpHeaders;
 }): string | undefined {
-  const xff = request?.headers?.['x-forwarded-for'];
-  const raw = Array.isArray(xff) ? xff[0] : xff;
-  const first = typeof raw === 'string' ? raw.split(',')[0].trim() : undefined;
-  return first || undefined;
+  return extractSinglePublicClientIp(request?.headers?.['x-forwarded-for']);
 }
 
 /**
@@ -3094,7 +3102,7 @@ In local/non-cloud MCP mode, this tool reads filePath from the MCP server filesy
 
 In hosted CLOUD_SERVICE mode, this tool is a two-call flow because hosted MCP cannot read your local filesystem:
 1. Call with filePath, contentType, parse options, and optional declaredSizeBytes. The hosted server mints a short-lived upload URL and returns a safe local curl PUT command plus nextToolCall.
-2. Run the returned curl command locally, then call firecrawl_parse again with uploadRef and the desired parse options. The hosted server calls /v2/parse server-side with your session credential.
+2. Run the returned curl command locally, then call firecrawl_parse again with uploadRef and the desired parse options. The hosted server calls /v2/parse server-side with your account credential or eligible anonymous keyless session.
 
 **Best for:** Extracting content from a local document (PDF, Word, Excel, HTML, etc.); pulling structured data out of a file with JSON format; converting binary documents into markdown for downstream reasoning.
 **Not recommended for:** Remote URLs (use firecrawl_scrape); multiple files at once (call parse multiple times); documents that require interactive actions, screenshots, or change tracking — those aren't supported by the parse endpoint.
@@ -3102,7 +3110,7 @@ In hosted CLOUD_SERVICE mode, this tool is a two-call flow because hosted MCP ca
 
 **Supported file types:** .html, .htm, .xhtml, .pdf, .docx, .doc, .odt, .rtf, .xlsx, .xls
 **Unsupported options:** actions, screenshot/branding/changeTracking formats, waitFor > 0, location, mobile, proxy values other than "auto" or "basic".
-**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted.
+**Privacy:** Set \`redactPII: true\` to return content with personally identifiable information redacted. \`zeroDataRetention: true\` requires an account or API key for a team where Zero Data Retention is enabled; omit it for anonymous keyless use.
 
 **CRITICAL - Format Selection (same rules as firecrawl_scrape):**
 When the user asks for SPECIFIC data points from a document, you MUST use JSON format with a schema. Only use markdown when the user needs the ENTIRE document content.
@@ -3118,8 +3126,7 @@ Add \`"parsers": ["pdf"]\` (optionally with \`pdfOptions.maxPages\`) when parsin
     "filePath": "/absolute/path/to/document.pdf",
     "contentType": "application/pdf",
     "formats": ["markdown"],
-    "parsers": ["pdf"],
-    "zeroDataRetention": true
+    "parsers": ["pdf"]
   }
 }
 \`\`\`
@@ -3131,8 +3138,7 @@ Add \`"parsers": ["pdf"]\` (optionally with \`pdfOptions.maxPages\`) when parsin
   "arguments": {
     "uploadRef": "upload-ref-from-phase-1",
     "formats": ["markdown"],
-    "parsers": ["pdf"],
-    "zeroDataRetention": true
+    "parsers": ["pdf"]
   }
 }
 \`\`\`

--- a/src/keyless-client-ip.ts
+++ b/src/keyless-client-ip.ts
@@ -1,0 +1,133 @@
+import net from 'node:net';
+
+function parseIpv4(value: string): number[] | undefined {
+  const parts = value.split('.');
+  if (parts.length !== 4) return undefined;
+  const bytes = parts.map((part) => {
+    if (!/^\d+$/.test(part)) return Number.NaN;
+    const value = Number(part);
+    return value >= 0 && value <= 255 ? value : Number.NaN;
+  });
+  return bytes.some(Number.isNaN) ? undefined : bytes;
+}
+
+function parseIpv6Words(value: string): number[] | undefined {
+  let input = value.toLowerCase();
+  const zoneIndex = input.indexOf('%');
+  if (zoneIndex >= 0) input = input.slice(0, zoneIndex);
+
+  const lastColon = input.lastIndexOf(':');
+  if (lastColon >= 0 && input.slice(lastColon + 1).includes('.')) {
+    const ipv4Tail = parseIpv4(input.slice(lastColon + 1));
+    if (!ipv4Tail) return undefined;
+    const firstWord = ((ipv4Tail[0] << 8) | ipv4Tail[1]).toString(16);
+    const secondWord = ((ipv4Tail[2] << 8) | ipv4Tail[3]).toString(16);
+    input = `${input.slice(0, lastColon)}:${firstWord}:${secondWord}`;
+  }
+
+  const halves = input.split('::');
+  if (halves.length > 2) return undefined;
+  const left = halves[0] ? halves[0].split(':') : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const parseWord = (part: string): number | undefined => {
+    if (!/^[0-9a-f]{1,4}$/.test(part)) return undefined;
+    return Number.parseInt(part, 16);
+  };
+  const words = [...left, ...right].map(parseWord);
+  if (words.some((word) => word === undefined)) return undefined;
+  const missing = halves.length === 2 ? 8 - words.length : 0;
+  if ((halves.length === 1 && words.length !== 8) || missing < 0) {
+    return undefined;
+  }
+  return [
+    ...(left.map(parseWord) as number[]),
+    ...Array(missing).fill(0),
+    ...(right.map(parseWord) as number[]),
+  ];
+}
+
+function ipv4In(
+  bytes: number[],
+  first: number,
+  secondStart?: number,
+  secondEnd?: number
+): boolean {
+  if (bytes[0] !== first) return false;
+  if (secondStart === undefined) return true;
+  return bytes[1] >= secondStart && bytes[1] <= (secondEnd ?? secondStart);
+}
+
+function isPublicIpLiteral(value: string): boolean {
+  const ipVersion = net.isIP(value);
+  if (ipVersion === 4) {
+    const bytes = parseIpv4(value);
+    if (!bytes) return false;
+    if (ipv4In(bytes, 0)) return false;
+    if (ipv4In(bytes, 10)) return false;
+    if (ipv4In(bytes, 100, 64, 127)) return false; // CGNAT
+    if (ipv4In(bytes, 127)) return false;
+    if (ipv4In(bytes, 169, 254)) return false;
+    if (ipv4In(bytes, 172, 16, 31)) return false;
+    if (ipv4In(bytes, 192, 0, 0)) return false;
+    if (ipv4In(bytes, 192, 0, 2)) return false; // TEST-NET-1
+    if (ipv4In(bytes, 192, 88, 99)) return false; // 6to4 relay anycast
+    if (ipv4In(bytes, 192, 168)) return false;
+    if (ipv4In(bytes, 198, 18, 19)) return false; // benchmark
+    if (ipv4In(bytes, 198, 51, 100)) return false; // TEST-NET-2
+    if (ipv4In(bytes, 203, 0, 113)) return false; // TEST-NET-3
+    if (bytes[0] >= 224) return false;
+    return true;
+  }
+
+  if (ipVersion === 6) {
+    const words = parseIpv6Words(value);
+    if (!words) return false;
+    const first = words[0];
+    const isAllZero = words.every((word) => word === 0);
+    if (isAllZero) return false;
+    if (words.slice(0, 7).every((word) => word === 0) && words[7] === 1) return false;
+    if ((first & 0xffc0) === 0xfe80) return false; // link-local
+    if ((first & 0xfe00) === 0xfc00) return false; // unique local
+    if ((first & 0xff00) === 0xff00) return false; // multicast
+    if ((first & 0xfff0) === 0x2001 && words[1] === 0x0db8) return false; // documentation
+    if (first === 0x2002) return false; // 6to4 embeds IPv4
+    if (first === 0x64 && words[1] === 0xff9b) return false; // well-known NAT64
+    const isMapped =
+      words.slice(0, 5).every((word) => word === 0) && words[5] === 0xffff;
+    if (isMapped) {
+      const bytes = [
+        words[6] >> 8,
+        words[6] & 0xff,
+        words[7] >> 8,
+        words[7] & 0xff,
+      ];
+      return isPublicIpLiteral(bytes.join('.'));
+    }
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns a trusted client identity only when the hosting edge has replaced
+ * X-Forwarded-For with one public address. Multi-hop or private values are
+ * client-spoofable at the application boundary, so keyless access fails closed.
+ */
+export function extractSinglePublicClientIp(
+  rawForwardedFor: string | string[] | undefined
+): string | undefined {
+  const raw = Array.isArray(rawForwardedFor)
+    ? rawForwardedFor[0]
+    : rawForwardedFor;
+  if (typeof raw !== 'string') return undefined;
+
+  const parts = raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length !== 1) return undefined;
+
+  const candidate = parts[0].replace(/^\[(.*)\]$/, '$1').toLowerCase();
+  return isPublicIpLiteral(candidate) ? candidate : undefined;
+}

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -226,6 +226,35 @@ async function startFakeFirecrawlBackend(options = {}) {
       return;
     }
 
+    if (req.method === 'POST' && req.url === '/v2/parse/upload-url') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          data: {
+            expiresAt: '2030-01-01T00:00:00.000Z',
+            headers: { 'x-upload-token': 'test-upload-token' },
+            maxSizeBytes: 1024,
+            method: 'PUT',
+            uploadRef: 'test-upload-ref',
+            uploadUrl: 'https://uploads.invalid/test-upload',
+          },
+          success: true,
+        })
+      );
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/v2/parse') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          data: { markdown: '# Parsed fixture' },
+          success: true,
+        })
+      );
+      return;
+    }
+
     if (req.method === 'GET' && req.url?.startsWith('/v2/monitor')) {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ success: true, data: [] }));
@@ -325,6 +354,13 @@ test('HTTP cloud transport preserves Firecrawl OAuth and well-known routes', asy
     anonymousTools.map((tool) => tool.name).sort(),
     ['firecrawl_parse', 'firecrawl_scrape', 'firecrawl_search']
   );
+  const anonymousParse = anonymousTools.find(
+    (tool) => tool.name === 'firecrawl_parse'
+  );
+  assert.ok(anonymousParse);
+  assert.match(anonymousParse.description, /redactPII/i);
+  assert.match(anonymousParse.description, /omit it for anonymous keyless/i);
+  assert.doesNotMatch(anonymousParse.description, /"zeroDataRetention"\s*:\s*true/);
 
   const initialize = await fetch(`http://127.0.0.1:${port}/v2/mcp`, {
     body: JSON.stringify({
@@ -755,7 +791,7 @@ test('HTTP cloud transport serves an eligible keyless client and forwards its IP
 
   const toolCall = await httpToolCall(port, {
     id: 13,
-    headers: { 'x-forwarded-for': '203.0.113.7, 10.0.0.1' },
+    headers: { 'x-forwarded-for': '8.8.8.7' },
     params: { arguments: { limit: 1, query: 'example domain' }, name: 'firecrawl_search' },
   });
   assert.equal(toolCall.status, 200);
@@ -766,13 +802,238 @@ test('HTTP cloud transport serves an eligible keyless client and forwards its IP
     (r) => r.url === '/v2/keyless/eligibility'
   );
   assert.equal(eligibilityCalls.length >= 1, true);
-  // The client's real (left-most XFF) IP and the secret must gate eligibility.
-  assert.equal(eligibilityCalls[0].headers['x-firecrawl-keyless-ip'], '203.0.113.7');
+  // nginx replaces XFF with one public client IP before this process sees it.
+  assert.equal(eligibilityCalls[0].headers['x-firecrawl-keyless-ip'], '8.8.8.7');
   assert.equal(
     eligibilityCalls[0].headers['x-firecrawl-keyless-secret'],
     'keyless-secret'
   );
   assert.equal(stderr.includes('TypeError'), false, stderr);
+});
+
+test('HTTP cloud keyless Parse completes both phases without credentials and forwards redactPII', async (t) => {
+  const backend = await startFakeFirecrawlBackend({ keylessEligible: true });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    HTTP_STREAMABLE_SERVER: 'true',
+    KEYLESS_PROXY_SECRET: 'keyless-parse-secret',
+    PORT: String(port),
+  });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const phaseOne = await httpToolCall(port, {
+    id: 'keyless-parse-phase-one',
+    headers: { 'x-forwarded-for': '8.8.8.43' },
+    params: {
+      arguments: {
+        contentType: 'application/pdf',
+        filePath: '/not-read-by-hosted-mcp/document.pdf',
+        formats: ['markdown'],
+        parsers: ['pdf'],
+      },
+      name: 'firecrawl_parse',
+    },
+  });
+  assert.equal(phaseOne.status, 200);
+  const phaseOneResult = parseSseJson(await phaseOne.text()).result;
+  assert.notEqual(phaseOneResult.isError, true);
+  const phaseOnePayload = JSON.parse(phaseOneResult.content[0].text);
+  assert.equal(phaseOnePayload.upload.uploadRef, 'test-upload-ref');
+  assert.equal(phaseOnePayload.nextToolCall.arguments.uploadRef, 'test-upload-ref');
+
+  const phaseTwo = await httpToolCall(port, {
+    id: 'keyless-parse-phase-two',
+    headers: { 'x-forwarded-for': '8.8.8.43' },
+    params: {
+      arguments: {
+        formats: ['markdown'],
+        redactPII: true,
+        uploadRef: 'test-upload-ref',
+      },
+      name: 'firecrawl_parse',
+    },
+  });
+  assert.equal(phaseTwo.status, 200);
+  assert.notEqual(parseSseJson(await phaseTwo.text()).result.isError, true);
+
+  const uploadCalls = backend.requests.filter((r) => r.url === '/v2/parse/upload-url');
+  const parseCalls = backend.requests.filter((r) => r.url === '/v2/parse');
+  assert.equal(uploadCalls.length, 1);
+  assert.equal(parseCalls.length, 1);
+  assert.equal(uploadCalls[0].headers.authorization, undefined);
+  assert.equal(parseCalls[0].headers.authorization, undefined);
+  assert.equal(parseCalls[0].body.uploadRef, 'test-upload-ref');
+  assert.equal(parseCalls[0].body.redactPII, true);
+  assert.equal(parseCalls[0].body.origin, 'mcp-fastmcp');
+  assert.equal(stderr.includes('keyless-parse-secret'), false, stderr);
+  assert.equal(stderr.includes('8.8.8.43'), false, stderr);
+});
+
+test('HTTP cloud keyless Parse rejects zeroDataRetention before any backend call', async (t) => {
+  const backend = await startFakeFirecrawlBackend({ keylessEligible: true });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    HTTP_STREAMABLE_SERVER: 'true',
+    KEYLESS_PROXY_SECRET: 'keyless-zdr-secret',
+    PORT: String(port),
+  });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  for (const arguments_ of [
+    { filePath: '/not-read-by-hosted-mcp/zdr.pdf', zeroDataRetention: true },
+    { uploadRef: 'test-upload-ref', zeroDataRetention: true },
+  ]) {
+    const response = await httpToolCall(port, {
+      id: `keyless-zdr-${'filePath' in arguments_ ? 'phase-one' : 'phase-two'}`,
+      headers: { 'x-forwarded-for': '8.8.8.44' },
+      params: { arguments: arguments_, name: 'firecrawl_parse' },
+    });
+    assert.equal(response.status, 200);
+    const result = parseSseJson(await response.text()).result;
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.code, 'KEYLESS_OPTION_NOT_AVAILABLE');
+    assert.equal(result.structuredContent.option, 'zeroDataRetention');
+    assert.match(result.structuredContent.message, /omit zeroDataRetention/i);
+  }
+  assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
+  assert.equal(stderr.includes('keyless-zdr-secret'), false, stderr);
+  assert.equal(stderr.includes('8.8.8.44'), false, stderr);
+});
+
+test('HTTP cloud keyless rejects multi-hop or non-public forwarded IP identity', async (t) => {
+  const backend = await startFakeFirecrawlBackend({ keylessEligible: true });
+  t.after(() => backend.close());
+
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    HTTP_STREAMABLE_SERVER: 'true',
+    KEYLESS_PROXY_SECRET: 'keyless-secret',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  for (const xff of ['8.8.8.8, 10.0.0.1', '10.0.0.1', '::1']) {
+    const response = await httpToolCall(port, {
+      id: `keyless-untrusted-ip-${xff}`,
+      headers: { 'x-forwarded-for': xff },
+      params: {
+        arguments: { limit: 1, query: 'example domain' },
+        name: 'firecrawl_search',
+      },
+    });
+    assert.equal(response.status, 200, xff);
+    const result = parseSseJson(await response.text()).result;
+    assert.equal(result.isError, true, xff);
+    assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE', xff);
+  }
+  assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
+});
+
+test('HTTP cloud authenticated Parse forwards ZDR for API-key and managed OAuth sessions', async (t) => {
+  const accountResource = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+  const backend = await startFakeFirecrawlBackend({
+    introspectionHandler: ({ token }) =>
+      token === 'fc-parse-api-key'
+        ? {
+            active: true,
+            api_key: 'fc-parse-api-key',
+            credential_purpose: 'general',
+            scope: 'firecrawl:global',
+          }
+        : token === 'fco_parse'
+        ? {
+            active: true,
+            api_key: 'fc-managed-parse-key',
+            api_key_id: '42',
+            aud: accountResource,
+            credential_purpose: 'hosted_mcp_oauth',
+            scope: 'firecrawl:global',
+            sub: '00000000-0000-4000-8000-000000000001',
+            team_id: '00000000-0000-4000-8000-000000000002',
+          }
+        : { active: false },
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp-oauth',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_MCP_RESOURCE_URL: accountResource,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  for (const [label, headers] of [
+    ['api-key', { 'x-firecrawl-api-key': 'fc-parse-api-key' }],
+    ['managed-oauth', { authorization: 'Bearer fco_parse' }],
+  ]) {
+    const phaseOne = await httpToolCall(port, {
+      endpoint: '/v2/mcp-oauth',
+      headers,
+      id: `${label}-parse-phase-one`,
+      params: {
+        arguments: { filePath: `/not-read-by-hosted-mcp/${label}.pdf`, zeroDataRetention: true },
+        name: 'firecrawl_parse',
+      },
+    });
+    assert.equal(phaseOne.status, 200);
+    const phaseOnePayload = JSON.parse(parseSseJson(await phaseOne.text()).result.content[0].text);
+    assert.equal(phaseOnePayload.nextToolCall.arguments.zeroDataRetention, true);
+
+    const phaseTwo = await httpToolCall(port, {
+      endpoint: '/v2/mcp-oauth',
+      headers,
+      id: `${label}-parse-phase-two`,
+      params: {
+        arguments: { uploadRef: 'test-upload-ref', zeroDataRetention: true },
+        name: 'firecrawl_parse',
+      },
+    });
+    assert.equal(phaseTwo.status, 200);
+    assert.notEqual(parseSseJson(await phaseTwo.text()).result.isError, true);
+  }
+
+  const uploads = backend.requests.filter((r) => r.url === '/v2/parse/upload-url');
+  const parses = backend.requests.filter((r) => r.url === '/v2/parse');
+  assert.equal(uploads.length, 2);
+  assert.equal(parses.length, 2);
+  assert.equal(uploads[0].headers.authorization, 'Bearer fc-parse-api-key');
+  assert.equal(parses[0].headers.authorization, 'Bearer fc-parse-api-key');
+  for (const request of [uploads[1], parses[1]]) {
+    const assertion = request.headers.authorization?.replace(/^Bearer /, '');
+    assert.match(assertion ?? '', /^fcmcp_/);
+    assert.equal(assertion?.includes('fc-managed-parse-key'), false);
+    assert.equal(assertion?.includes('fco_parse'), false);
+  }
+  assert.equal(parses[0].body.zeroDataRetention, true);
+  assert.equal(parses[1].body.zeroDataRetention, true);
 });
 
 test('HTTP cloud transport returns recovery when keyless identity has no client IP', async (t) => {


### PR DESCRIPTION
## Summary
- reject `zeroDataRetention: true` after anonymous/keyless session resolution and before any Core eligibility, upload, or Parse endpoint call
- require exactly one syntactically valid source IP from the trusted hosted edge for anonymous keyless traffic (corrected by #335: that source may be an internal ingress address)
- keep `redactPII` available to anonymous Parse and correct hosted Parse guidance/examples
- lock keyless two-phase Parse, early rejection, forwarded-IP trust, API-key forwarding, and managed-OAuth delegated-credential forwarding with HTTP smoke coverage

## Scope
MCP server only. No Core, DB, Infra, endpoint-routing, or Stage-1/2 contract changes.

## Regression lineage
The intended guard and tests existed before the PR #308 train but were omitted during the pre-merge reconciliation. This restores the established contract on current `main`, without a blind revert.

## Verification
- `npm run build`
- targeted hosted smoke: 4 tests pass, including the new Parse regression cases (forwarded-IP deployment compatibility is corrected in #335)
- `npm test`: 43/43 pass
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`

## Release verification after merge
`firecrawl-mcp-server` auto-deploys via GHCR/Keel. From a clean eligible network, verify anonymous tools/list still shows exactly Search/Scrape/Parse; verify anonymous ZDR returns a structured error with no upload instructions; then run a small non-sensitive two-phase Parse fixture and an API-key Parse smoke. Do not log credentials, signed URLs, or upload refs.

## Follow-up outside this PR
Infra/security should independently audit lifecycle handling for uploaded-but-never-parsed objects before making stronger retention claims.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787682439&installation_model_id=11126&pr_number=334&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F334&signature=99ef988b3c5dce2871cccd1a58e73877c16554bfb4c0f666e30c4d5af81074c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the hosted keyless Parse ZDR boundary and tightens client IP trust. Anonymous keyless can still use `redactPII`; `zeroDataRetention: true` is denied and multi‑hop/private `X-Forwarded-For` is not trusted; authenticated sessions can use ZDR.

- **Bug Fixes**
  - Fail fast on `zeroDataRetention` in anonymous keyless Parse before any upload or backend call; returns `KEYLESS_OPTION_NOT_AVAILABLE` with guidance.
  - Require exactly one public client IP from `X-Forwarded-For`; otherwise reject keyless with `KEYLESS_ACCESS_NOT_AVAILABLE`. Forward the trusted IP to `/v2/keyless/eligibility`.
  - Keep `redactPII` for keyless and update `firecrawl_parse` docs/examples to note ZDR requires an account or API key.
  - Add HTTP smoke tests to lock behavior: keyless two-phase Parse works without credentials and forwards `redactPII`; early ZDR rejection; reject multi-hop/private XFF; ZDR allowed and forwarded for API key and managed OAuth sessions.

<sup>Written for commit f302d83983bb65dcaecc78660b742784451f16c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


