### PR TITLE
fix(mcp): preserve trusted proxy keyless identity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { z } from 'zod';
-import { extractSinglePublicClientIp } from './keyless-client-ip';
+import { extractSingleTrustedClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
 import {
@@ -2027,7 +2027,7 @@ function resolveApiBaseUrl(): string {
 function extractClientIp(request?: {
   headers: IncomingHttpHeaders;
 }): string | undefined {
-  return extractSinglePublicClientIp(request?.headers?.['x-forwarded-for']);
+  return extractSingleTrustedClientIp(request?.headers?.['x-forwarded-for']);
 }
 
 /**

--- a/src/keyless-client-ip.ts
+++ b/src/keyless-client-ip.ts
@@ -1,120 +1,14 @@
 import net from 'node:net';
 
-function parseIpv4(value: string): number[] | undefined {
-  const parts = value.split('.');
-  if (parts.length !== 4) return undefined;
-  const bytes = parts.map((part) => {
-    if (!/^\d+$/.test(part)) return Number.NaN;
-    const value = Number(part);
-    return value >= 0 && value <= 255 ? value : Number.NaN;
-  });
-  return bytes.some(Number.isNaN) ? undefined : bytes;
-}
-
-function parseIpv6Words(value: string): number[] | undefined {
-  let input = value.toLowerCase();
-  const zoneIndex = input.indexOf('%');
-  if (zoneIndex >= 0) input = input.slice(0, zoneIndex);
-
-  const lastColon = input.lastIndexOf(':');
-  if (lastColon >= 0 && input.slice(lastColon + 1).includes('.')) {
-    const ipv4Tail = parseIpv4(input.slice(lastColon + 1));
-    if (!ipv4Tail) return undefined;
-    const firstWord = ((ipv4Tail[0] << 8) | ipv4Tail[1]).toString(16);
-    const secondWord = ((ipv4Tail[2] << 8) | ipv4Tail[3]).toString(16);
-    input = `${input.slice(0, lastColon)}:${firstWord}:${secondWord}`;
-  }
-
-  const halves = input.split('::');
-  if (halves.length > 2) return undefined;
-  const left = halves[0] ? halves[0].split(':') : [];
-  const right = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
-  const parseWord = (part: string): number | undefined => {
-    if (!/^[0-9a-f]{1,4}$/.test(part)) return undefined;
-    return Number.parseInt(part, 16);
-  };
-  const words = [...left, ...right].map(parseWord);
-  if (words.some((word) => word === undefined)) return undefined;
-  const missing = halves.length === 2 ? 8 - words.length : 0;
-  if ((halves.length === 1 && words.length !== 8) || missing < 0) {
-    return undefined;
-  }
-  return [
-    ...(left.map(parseWord) as number[]),
-    ...Array(missing).fill(0),
-    ...(right.map(parseWord) as number[]),
-  ];
-}
-
-function ipv4In(
-  bytes: number[],
-  first: number,
-  secondStart?: number,
-  secondEnd?: number
-): boolean {
-  if (bytes[0] !== first) return false;
-  if (secondStart === undefined) return true;
-  return bytes[1] >= secondStart && bytes[1] <= (secondEnd ?? secondStart);
-}
-
-function isPublicIpLiteral(value: string): boolean {
-  const ipVersion = net.isIP(value);
-  if (ipVersion === 4) {
-    const bytes = parseIpv4(value);
-    if (!bytes) return false;
-    if (ipv4In(bytes, 0)) return false;
-    if (ipv4In(bytes, 10)) return false;
-    if (ipv4In(bytes, 100, 64, 127)) return false; // CGNAT
-    if (ipv4In(bytes, 127)) return false;
-    if (ipv4In(bytes, 169, 254)) return false;
-    if (ipv4In(bytes, 172, 16, 31)) return false;
-    if (ipv4In(bytes, 192, 0, 0)) return false;
-    if (ipv4In(bytes, 192, 0, 2)) return false; // TEST-NET-1
-    if (ipv4In(bytes, 192, 88, 99)) return false; // 6to4 relay anycast
-    if (ipv4In(bytes, 192, 168)) return false;
-    if (ipv4In(bytes, 198, 18, 19)) return false; // benchmark
-    if (ipv4In(bytes, 198, 51, 100)) return false; // TEST-NET-2
-    if (ipv4In(bytes, 203, 0, 113)) return false; // TEST-NET-3
-    if (bytes[0] >= 224) return false;
-    return true;
-  }
-
-  if (ipVersion === 6) {
-    const words = parseIpv6Words(value);
-    if (!words) return false;
-    const first = words[0];
-    const isAllZero = words.every((word) => word === 0);
-    if (isAllZero) return false;
-    if (words.slice(0, 7).every((word) => word === 0) && words[7] === 1) return false;
-    if ((first & 0xffc0) === 0xfe80) return false; // link-local
-    if ((first & 0xfe00) === 0xfc00) return false; // unique local
-    if ((first & 0xff00) === 0xff00) return false; // multicast
-    if ((first & 0xfff0) === 0x2001 && words[1] === 0x0db8) return false; // documentation
-    if (first === 0x2002) return false; // 6to4 embeds IPv4
-    if (first === 0x64 && words[1] === 0xff9b) return false; // well-known NAT64
-    const isMapped =
-      words.slice(0, 5).every((word) => word === 0) && words[5] === 0xffff;
-    if (isMapped) {
-      const bytes = [
-        words[6] >> 8,
-        words[6] & 0xff,
-        words[7] >> 8,
-        words[7] & 0xff,
-      ];
-      return isPublicIpLiteral(bytes.join('.'));
-    }
-    return true;
-  }
-
-  return false;
-}
-
 /**
- * Returns a trusted client identity only when the hosting edge has replaced
- * X-Forwarded-For with one public address. Multi-hop or private values are
- * client-spoofable at the application boundary, so keyless access fails closed.
+ * Accept exactly one syntactically valid source IP from the hosting edge.
+ *
+ * The hosted nginx proxy overwrites X-Forwarded-For with its remote peer, so
+ * the application must reject multi-hop/client-crafted values. That peer can
+ * legitimately be a private address between trusted ingress hops; requiring a
+ * public address would disable keyless traffic in that deployment topology.
  */
-export function extractSinglePublicClientIp(
+export function extractSingleTrustedClientIp(
   rawForwardedFor: string | string[] | undefined
 ): string | undefined {
   const raw = Array.isArray(rawForwardedFor)
@@ -129,5 +23,5 @@ export function extractSinglePublicClientIp(
   if (parts.length !== 1) return undefined;
 
   const candidate = parts[0].replace(/^\[(.*)\]$/, '$1').toLowerCase();
-  return isPublicIpLiteral(candidate) ? candidate : undefined;
+  return net.isIP(candidate) ? candidate : undefined;
 }

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -802,7 +802,7 @@ test('HTTP cloud transport serves an eligible keyless client and forwards its IP
     (r) => r.url === '/v2/keyless/eligibility'
   );
   assert.equal(eligibilityCalls.length >= 1, true);
-  // nginx replaces XFF with one public client IP before this process sees it.
+  // nginx replaces XFF with one source IP before this process sees it.
   assert.equal(eligibilityCalls[0].headers['x-firecrawl-keyless-ip'], '8.8.8.7');
   assert.equal(
     eligibilityCalls[0].headers['x-firecrawl-keyless-secret'],
@@ -918,7 +918,7 @@ test('HTTP cloud keyless Parse rejects zeroDataRetention before any backend call
   assert.equal(stderr.includes('8.8.8.44'), false, stderr);
 });
 
-test('HTTP cloud keyless rejects multi-hop or non-public forwarded IP identity', async (t) => {
+test('HTTP cloud keyless rejects multi-hop or malformed forwarded IP identity', async (t) => {
   const backend = await startFakeFirecrawlBackend({ keylessEligible: true });
   t.after(() => backend.close());
 
@@ -934,7 +934,7 @@ test('HTTP cloud keyless rejects multi-hop or non-public forwarded IP identity',
   t.after(() => stopChild(child));
   await waitForHealth(port, child);
 
-  for (const xff of ['8.8.8.8, 10.0.0.1', '10.0.0.1', '::1']) {
+  for (const xff of ['8.8.8.8, 10.0.0.1', 'not-an-ip']) {
     const response = await httpToolCall(port, {
       id: `keyless-untrusted-ip-${xff}`,
       headers: { 'x-forwarded-for': xff },
@@ -949,6 +949,36 @@ test('HTTP cloud keyless rejects multi-hop or non-public forwarded IP identity',
     assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE', xff);
   }
   assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
+});
+
+test('HTTP cloud keyless accepts one internal IP supplied by the trusted edge', async (t) => {
+  const backend = await startFakeFirecrawlBackend({ keylessEligible: true });
+  t.after(() => backend.close());
+
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    HTTP_STREAMABLE_SERVER: 'true',
+    KEYLESS_PROXY_SECRET: 'keyless-secret',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    id: 'keyless-trusted-internal-ip',
+    headers: { 'x-forwarded-for': '10.0.0.1' },
+    params: {
+      arguments: { limit: 1, query: 'example domain' },
+      name: 'firecrawl_search',
+    },
+  });
+  assert.equal(response.status, 200);
+  assert.notEqual(parseSseJson(await response.text()).result.isError, true);
+  const eligibility = backend.requests.find((r) => r.url === '/v2/keyless/eligibility');
+  assert.equal(eligibility.headers['x-firecrawl-keyless-ip'], '10.0.0.1');
 });
 
 test('HTTP cloud authenticated Parse forwards ZDR for API-key and managed OAuth sessions', async (t) => {


### PR DESCRIPTION
## Summary
- retain the #334 keyless ZDR rejection and multi-hop XFF rejection
- accept one valid internal source IP from the trusted nginx/ingress path; production nginx replaces client-supplied XFF before Node receives it
- prove anonymous keyless works with the private inter-proxy address and still fails closed for multi-hop or malformed XFF

## Incident correction
#334 initially required a public IP. The post-deploy anonymous `firecrawl_search` probe returned `KEYLESS_ACCESS_NOT_AVAILABLE`; the trusted nginx hop supplies an internal address in production. This PR restores the working deployment topology without accepting a client-crafted multi-hop XFF value.

## Verification
- `npm run lint`
- `npm run build`
- targeted hosted keyless suite: 5/5
- `npx tsc --noEmit`
- `npm test`: 45/45
- `git diff --check`

## Release verification
After the normal GHCR/Keel rollout, run an anonymous `/v2/mcp` `firecrawl_search` call (must succeed), anonymous ZDR Parse (must return `KEYLESS_OPTION_NOT_AVAILABLE` with no upload instructions), and backward-compatibility endpoint checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787683602&installation_model_id=11126&pr_number=335&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F335&signature=0328f116375009ad9c06f96529a1a4583e9bf45d96c934a48fe596d2056d4082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves trusted proxy keyless identity by accepting exactly one syntactically valid IP from `X-Forwarded-For` (including private IPs from nginx/ingress), while still rejecting multi-hop and malformed values. Restores anonymous keyless in production without reopening spoofing.

- **Bug Fixes**
  - Accept one valid IP from `X-Forwarded-For` and reject multiple or invalid entries.
  - Continue to fail closed for multi-hop or malformed headers; anonymous ZDR remains unavailable.
  - Forward the trusted IP to the backend via `x-firecrawl-keyless-ip`.

- **Refactors**
  - Replaced `extractSinglePublicClientIp` with `extractSingleTrustedClientIp`.
  - Removed custom IP classification and parsing; now uses `net.isIP`.

<sup>Written for commit f6e7f202cbc8bd9151bcdbe6b8381625143162de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

