### PR TITLE
fix(mcp): restore real keyless identity and recovery correlation

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -15,7 +15,7 @@ http {
       proxy_read_timeout 30s;
       proxy_send_timeout 30s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://__MCP_SEARCH_UPSTREAM__;
     }
@@ -30,7 +30,7 @@ http {
       proxy_read_timeout 30s;
       proxy_send_timeout 30s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app;
     }
@@ -45,7 +45,7 @@ http {
       proxy_read_timeout 620s;
       proxy_send_timeout 620s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app;
     }
@@ -58,7 +58,7 @@ http {
       proxy_read_timeout 620s;
       proxy_send_timeout 620s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app;
     }
@@ -74,7 +74,7 @@ http {
       proxy_read_timeout 620s;
       proxy_send_timeout 620s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       rewrite ^ /v2/mcp break;
       proxy_pass http://app;
@@ -94,7 +94,7 @@ http {
       proxy_read_timeout 620s;
       proxy_send_timeout 620s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://__MCP_SEARCH_UPSTREAM__;
     }
@@ -113,7 +113,7 @@ http {
       proxy_read_timeout 620s;
       proxy_send_timeout 620s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       rewrite ^/[^/]+(/v2/mcp-search.*)$ $1 break;
       proxy_pass http://__MCP_SEARCH_UPSTREAM__;
@@ -132,7 +132,7 @@ http {
       proxy_send_timeout 620s;
       proxy_set_header X-Firecrawl-API-Key $apikey;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       rewrite ^ /v2/mcp break;
       proxy_pass http://app;
@@ -144,7 +144,7 @@ http {
       proxy_read_timeout 620s;
       proxy_send_timeout 620s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       rewrite ^/v(?:1|2)/(.*)$ /$1 break;
       proxy_pass http://app;
@@ -185,7 +185,7 @@ http {
       proxy_send_timeout 620s;
       proxy_pass http://app/mcp;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
@@ -198,7 +198,7 @@ http {
       proxy_send_timeout 620s;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app/messages;
     }
@@ -213,7 +213,7 @@ http {
       proxy_set_header Connection "";
       proxy_set_header Accept "text/event-stream";
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app/sse;
     }
@@ -223,7 +223,7 @@ http {
       proxy_read_timeout 5s;
       proxy_send_timeout 5s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app/health;
     }
@@ -236,7 +236,7 @@ http {
       proxy_read_timeout 5s;
       proxy_send_timeout 5s;
       proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $http_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_pass http://app/ready;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
 import {
   credentialForOutboundRequest,
+  copyManagedOAuthApiKey,
   CredentialValidationUnavailableError,
   hasCredential,
   hasManagedOAuthCredential,
@@ -47,6 +48,7 @@ interface SessionData extends CredentialSession {
   apiKeyId?: string;
   oauthClientId?: string;
   resource?: string;
+  requestId?: string;
   [key: string]: unknown;
 }
 
@@ -880,9 +882,13 @@ function isHostedKeylessSession(session?: SessionData): boolean {
   );
 }
 
-function recoveryPayload(code: string): Record<string, unknown> {
+function recoveryPayload(
+  code: string,
+  requestId = randomUUID()
+): Record<string, unknown> {
   return {
     code,
+    request_id: requestId,
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
       code === 'CREDENTIAL_INVALID'
@@ -969,24 +975,34 @@ function guardHostedTool(
       };
     },
     execute: async (args, context) => {
-      if (context.session?.credentialError) {
-        const payload = recoveryPayload('CREDENTIAL_INVALID');
-        throw new UserError(String(payload.message), payload);
-      }
-      if (isHostedKeylessSession(context.session) && !keylessTool) {
-        const payload = recoveryPayload('KEYLESS_TOOL_NOT_AVAILABLE');
-        throw new UserError(String(payload.message), payload);
-      }
-      if (!logActions) return execute(args, context);
-
       const requestId = randomUUID();
-      emitActionLog(tool.name, 'started', context.session, undefined, requestId);
+      const invocationSession: SessionData = {
+        ...context.session,
+        requestId,
+      };
+      copyManagedOAuthApiKey(context.session, invocationSession);
+      const invocationContext = {
+        ...context,
+        session: invocationSession,
+      };
+
+      if (invocationSession.credentialError) {
+        const payload = recoveryPayload('CREDENTIAL_INVALID', requestId);
+        throw new UserError(String(payload.message), payload);
+      }
+      if (isHostedKeylessSession(invocationSession) && !keylessTool) {
+        const payload = recoveryPayload('KEYLESS_TOOL_NOT_AVAILABLE', requestId);
+        throw new UserError(String(payload.message), payload);
+      }
+      if (!logActions) return execute(args, invocationContext);
+
+      emitActionLog(tool.name, 'started', invocationSession, undefined, requestId);
       try {
-        const result = await execute(args, context);
-        emitActionLog(tool.name, 'success', context.session, undefined, requestId);
+        const result = await execute(args, invocationContext);
+        emitActionLog(tool.name, 'success', invocationSession, undefined, requestId);
         return result;
       } catch (error) {
-        emitActionLog(tool.name, 'error', context.session, error, requestId);
+        emitActionLog(tool.name, 'error', invocationSession, error, requestId);
         throw error;
       }
     },
@@ -1589,7 +1605,7 @@ async function executeHostedParse(
 
   if (isHostedKeylessSession(session) && args.zeroDataRetention === true) {
     const payload = {
-      ...recoveryPayload('KEYLESS_OPTION_NOT_AVAILABLE'),
+      ...recoveryPayload('KEYLESS_OPTION_NOT_AVAILABLE', session?.requestId),
       option: 'zeroDataRetention',
       message:
         'Zero Data Retention is not available in anonymous keyless mode. Omit zeroDataRetention to parse with keyless access, or connect an account or configure an API key for a team where Zero Data Retention is enabled, then retry.',
@@ -2076,7 +2092,10 @@ async function keylessPost(
     isHostedKeylessSession(session) &&
     (!session?.keylessClientIp || !(await keylessEligible(session.keylessClientIp)))
   ) {
-    const payload = recoveryPayload('KEYLESS_ACCESS_NOT_AVAILABLE');
+    const payload = recoveryPayload(
+      'KEYLESS_ACCESS_NOT_AVAILABLE',
+      session?.requestId
+    );
     throw new UserError(String(payload.message), payload);
   }
   const headers: Record<string, string> = {
@@ -2097,7 +2116,10 @@ async function keylessPost(
   const json: any = await response.json().catch(() => ({}));
   if (!response.ok) {
     if (isHostedKeylessSession(session) && [401, 402, 429].includes(response.status)) {
-      const payload = recoveryPayload('KEYLESS_QUOTA_EXHAUSTED');
+      const payload = recoveryPayload(
+        'KEYLESS_QUOTA_EXHAUSTED',
+        session?.requestId
+      );
       throw new UserError(String(payload.message), payload);
     }
     throw new Error(

--- a/src/keyless-client-ip.ts
+++ b/src/keyless-client-ip.ts
@@ -3,14 +3,17 @@ import net from 'node:net';
 /**
  * Accept exactly one syntactically valid source IP from the hosting edge.
  *
- * The hosted nginx proxy overwrites X-Forwarded-For with its remote peer, so
- * the application must reject multi-hop/client-crafted values. That peer can
- * legitimately be a private address between trusted ingress hops; requiring a
- * public address would disable keyless traffic in that deployment topology.
+ * The hosted nginx proxy preserves the chain sanitized by its trusted ingress,
+ * so the application must reject multi-hop/client-crafted values. A single
+ * address may legitimately be private in direct or local test topologies;
+ * requiring a public address here would make those deployments unavailable.
  */
 export function extractSingleTrustedClientIp(
   rawForwardedFor: string | string[] | undefined
 ): string | undefined {
+  if (Array.isArray(rawForwardedFor) && rawForwardedFor.length !== 1) {
+    return undefined;
+  }
   const raw = Array.isArray(rawForwardedFor)
     ? rawForwardedFor[0]
     : rawForwardedFor;

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -802,7 +802,7 @@ test('HTTP cloud transport serves an eligible keyless client and forwards its IP
     (r) => r.url === '/v2/keyless/eligibility'
   );
   assert.equal(eligibilityCalls.length >= 1, true);
-  // nginx replaces XFF with one source IP before this process sees it.
+  // nginx preserves the single source IP sanitized by the trusted ingress.
   assert.equal(eligibilityCalls[0].headers['x-firecrawl-keyless-ip'], '8.8.8.7');
   assert.equal(
     eligibilityCalls[0].headers['x-firecrawl-keyless-secret'],

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -48,6 +48,17 @@ function parseSseJson(body) {
   return JSON.parse(dataLine.slice('data: '.length));
 }
 
+function assertServerGeneratedRequestId(payload, untrustedValues = []) {
+  assert.match(
+    payload.request_id,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  );
+  for (const value of untrustedValues) {
+    assert.notEqual(payload.request_id, value);
+  }
+  return payload.request_id;
+}
+
 function spawnServer(env) {
   const child = spawn(process.execPath, ['dist/index.js'], {
     env: {
@@ -897,13 +908,19 @@ test('HTTP cloud keyless Parse rejects zeroDataRetention before any backend call
   t.after(() => stopChild(child));
   await waitForHealth(port, child);
 
+  const requestIds = [];
   for (const arguments_ of [
     { filePath: '/not-read-by-hosted-mcp/zdr.pdf', zeroDataRetention: true },
     { uploadRef: 'test-upload-ref', zeroDataRetention: true },
   ]) {
+    const clientRequestId = `client-${'filePath' in arguments_ ? 'phase-one' : 'phase-two'}`;
+    const jsonRpcId = `keyless-zdr-${'filePath' in arguments_ ? 'phase-one' : 'phase-two'}`;
     const response = await httpToolCall(port, {
-      id: `keyless-zdr-${'filePath' in arguments_ ? 'phase-one' : 'phase-two'}`,
-      headers: { 'x-forwarded-for': '8.8.8.44' },
+      id: jsonRpcId,
+      headers: {
+        'x-forwarded-for': '8.8.8.44',
+        'x-request-id': clientRequestId,
+      },
       params: { arguments: arguments_, name: 'firecrawl_parse' },
     });
     assert.equal(response.status, 200);
@@ -912,8 +929,24 @@ test('HTTP cloud keyless Parse rejects zeroDataRetention before any backend call
     assert.equal(result.structuredContent.code, 'KEYLESS_OPTION_NOT_AVAILABLE');
     assert.equal(result.structuredContent.option, 'zeroDataRetention');
     assert.match(result.structuredContent.message, /omit zeroDataRetention/i);
+    requestIds.push(
+      assertServerGeneratedRequestId(result.structuredContent, [
+        clientRequestId,
+        jsonRpcId,
+      ])
+    );
   }
   assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
+  const loggedErrorRequestIds = stderr
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('[MCP_ACTION] '))
+    .map((line) => JSON.parse(line.slice('[MCP_ACTION] '.length)))
+    .filter(
+      (entry) =>
+        entry.tool_name === 'firecrawl_parse' && entry.status === 'error'
+    )
+    .map((entry) => entry.request_id);
+  assert.deepEqual(new Set(loggedErrorRequestIds), new Set(requestIds));
   assert.equal(stderr.includes('keyless-zdr-secret'), false, stderr);
   assert.equal(stderr.includes('8.8.8.44'), false, stderr);
 });
@@ -1090,14 +1123,18 @@ test('HTTP cloud transport returns recovery when keyless identity has no client 
   // Discovery remains keyless-first, but the actual call fails closed because
   // the API cannot enforce the anonymous per-IP allowance.
   const toolCall = await httpToolCall(port, {
-    id: 14,
-    headers: {},
+    id: 'client-json-rpc-id',
+    headers: { 'x-request-id': 'client-request-header-id' },
     params: { arguments: { limit: 1, query: 'example domain' }, name: 'firecrawl_search' },
   });
   assert.equal(toolCall.status, 200);
   const result = parseSseJson(await toolCall.text()).result;
   assert.equal(result.isError, true);
   assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE');
+  assertServerGeneratedRequestId(result.structuredContent, [
+    'client-json-rpc-id',
+    'client-request-header-id',
+  ]);
   assert.equal(backend.requests.some((r) => r.url === '/v2/search'), false);
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
@@ -1473,7 +1510,10 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   assert.deepEqual(parseSseJson(await invalidList.text()).result.tools, []);
 
   const invalidCall = await httpToolCall(port, {
-    headers: { authorization: 'Bearer fc-invalid' },
+    headers: {
+      authorization: 'Bearer fc-invalid',
+      'x-request-id': 'invalid-client-request-header-id',
+    },
     id: 3,
     params: { arguments: { query: 'x' }, name: 'firecrawl_search' },
   });
@@ -1481,4 +1521,8 @@ test('account OAuth tokens cannot replay on keyless and invalid keys get correct
   const result = parseSseJson(await invalidCall.text()).result;
   assert.equal(result.isError, true);
   assert.equal(result.structuredContent.code, 'CREDENTIAL_INVALID');
+  assertServerGeneratedRequestId(result.structuredContent, [
+    3,
+    'invalid-client-request-header-id',
+  ]);
 });

--- a/tests/nginx-config.test.mjs
+++ b/tests/nginx-config.test.mjs
@@ -81,3 +81,15 @@ test('search routes are rendered to a fixed upstream and readiness reaches Node'
   const ready = locationBody('location = /ready');
   assert.match(ready, /proxy_pass http:\/\/app\/ready;/);
 });
+
+test('nginx preserves only the trusted edge forwarding chain', () => {
+  const forwardedForDirectives = [
+    ...config.matchAll(/proxy_set_header X-Forwarded-For ([^;]+);/g),
+  ];
+  assert.ok(forwardedForDirectives.length > 0);
+  for (const [, value] of forwardedForDirectives) {
+    assert.equal(value, '$http_x_forwarded_for');
+  }
+  assert.doesNotMatch(config, /X-Forwarded-For \$remote_addr/);
+  assert.doesNotMatch(config, /\$proxy_add_x_forwarded_for/);
+});


### PR DESCRIPTION
## Summary

- preserve Traefik's sanitized `X-Forwarded-For` value instead of replacing it with the Traefik pod IP
- keep the MCP boundary fail-closed for missing, malformed, duplicate, or multi-hop identities
- restore server-generated recovery `request_id` values and correlate execution-time recovery responses with `[MCP_ACTION]` error events

## Why

Hosted anonymous traffic is currently bucketed by the Traefik pod address because nginx overwrites `X-Forwarded-For` with `$remote_addr`. Core uses the forwarded value for keyless quotas, credits, team identity, audit data, and Spur checks. This change restores the real edge-sanitized client identity without trusting client-provided forwarding chains.

The Stage-1 recovery contract also lost its server-generated `request_id`. This PR restores that correlation boundary without accepting JSON-RPC IDs or request headers as recovery IDs.

## Scope / safety

- exactly two commits: proxy identity, then recovery IDs
- no schema, dependency, tool-surface, endpoint, auth-policy, or infra change
- Traefik v3.5 default forwarded-header behavior was exercised locally with positive and negative controls
- production topology checked read-only: `externalTrafficPolicy: Local`, MCP Services are `ClusterIP`, and no `forwardedHeaders` override is configured
- expected rollout effect: old Traefik-IP keyless buckets age out under their existing TTL; real-client buckets begin independently
- expected monitoring effect: Spur sees real client IPs, so VPN/proxy rejection volume may increase to its intended level

## Validation

- `npm test` — 46/46 passing
- `npm run lint`
- `docker build -f Dockerfile.service -t firecrawl-mcp:keyless-identity-recovery-id .`
- `nginx -t` inside the built service image
- Traefik `v3.5.0` -> nginx -> MCP -> fake Core wire test:
  - baseline keyless Search succeeds with one stable identity
  - forged single XFF never reaches Core as the attacker-selected identity
  - forged multi-hop XFF never reaches Core as an attacker-selected identity
- ZDR phase 1 and phase 2 recoveries:
  - include UUIDv4 `request_id`
  - reject client JSON-RPC/header IDs as the recovery ID
  - match the `[MCP_ACTION]` error `request_id`
  - make zero backend requests
- managed OAuth Parse remains green, covering preservation of the non-enumerable managed credential when invocation context is correlated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787686475&installation_model_id=11126&pr_number=336&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F336&signature=a88352e924d73bdb3e832f4b5fec31b3fc1c3aa8d6951142935af551307633a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore real hosted keyless identity and server-generated recovery correlation. This forwards the edge-sanitized client IP and adds reliable `request_id` values that match `[MCP_ACTION]` logs, fixing per-IP quotas and recovery flows.

- **Bug Fixes**
  - Proxy/identity: forward `X-Forwarded-For` from `$http_x_forwarded_for` and reject multi-hop or malformed values.
  - Recovery correlation: generate `request_id` on the server, include it in recovery payloads, and use the same ID in `[MCP_ACTION]` logs; ignore client JSON-RPC IDs and `x-request-id`.
  - Session flow: carry the `requestId` through tool execution and keyless recoveries (eligibility, quota, ZDR) and preserve the managed OAuth API key in the invocation context.

<sup>Written for commit b8dfb26ed74eeb7a1dca7be31575bbe3dd7057ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

