### PR TITLE
fix(search): describe OAuth-only authentication accurately

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -510,6 +510,11 @@ async function authenticateRequest(
           keylessClientIp: extractClientIp(request),
         };
       }
+      if (!profile.acceptApiKeys) {
+        throw new Error(
+          `OAuth access token required for the Firecrawl MCP resource ${profile.endpoint}`
+        );
+      }
       throw new Error(
         'Firecrawl credentials required: OAuth access token (Authorization: Bearer fco_...) or API key (x-firecrawl-api-key)'
       );

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -569,6 +569,9 @@ test('primary search profile is OAuth-only, six-tool frozen, and ready without k
     method: 'tools/list',
   });
   assert.equal(anonymous.status, 401);
+  const anonymousBody = await anonymous.text();
+  assert.match(anonymousBody, /OAuth access token required/);
+  assert.doesNotMatch(anonymousBody, /API key/i);
   assert.match(
     anonymous.headers.get('www-authenticate') ?? '',
     /oauth-protected-resource\/v2\/mcp-search/


### PR DESCRIPTION
## Summary
- make anonymous OAuth-only search requests state the actual supported credential
- preserve the existing full/account error contract
- lock the public error text with the primary-search integration test

## Verification
- `npm test` (49 passed)
- `npm run lint`
- `git diff --check`

This is a copy-only correction to the Stage-2 OAuth-only search contract; it does not change authorization behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787772777&installation_model_id=11126&pr_number=339&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F339&signature=4c164ae80ce56bcd1282350a9d3e9b830d75cd734f751989180a6d12b794488c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified OAuth-only search auth errors so anonymous requests clearly state that an OAuth access token is required. Removes misleading API key guidance without changing auth behavior.

- **Bug Fixes**
  - For OAuth-only profiles, 401 errors now say “OAuth access token required …” and no longer mention API keys.
  - Tests updated to lock the public error text and preserve the status and WWW-Authenticate contract.

<sup>Written for commit c43b6e1698b1b2289a8d54b82729ab2cd39753d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

