### PR TITLE
fix: skip cloud-only research tools on self-hosted instances

### DIFF
--- a/src/research.ts
+++ b/src/research.ts
@@ -35,6 +35,23 @@ type GetClient = (session?: SessionData) => unknown;
 const BASE = '/v2/search/research';
 const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
 
+const DEFAULT_CLOUD_API_URL = 'https://api.firecrawl.dev';
+
+/**
+ * The research index only exists on the Firecrawl cloud API; self-hosted
+ * instances have no `/v2/search/research/*` routes and answer every research
+ * call with a 404 (firecrawl/firecrawl-mcp-server#341). A target counts as
+ * self-hosted when FIRECRAWL_API_URL points somewhere other than the cloud —
+ * except under the hosted multi-tenant deployment (CLOUD_SERVICE), which also
+ * sets FIRECRAWL_API_URL but always fronts the cloud API.
+ */
+function targetsSelfHostedApi(): boolean {
+  if (process.env.CLOUD_SERVICE === 'true') return false;
+  const apiUrl = process.env.FIRECRAWL_API_URL?.trim().replace(/\/$/, '');
+  if (!apiUrl) return false;
+  return apiUrl !== DEFAULT_CLOUD_API_URL;
+}
+
 /** Append a value (or repeated array values) to a URLSearchParams instance. */
 function appendParam(
   params: URLSearchParams,
@@ -232,6 +249,17 @@ export function registerResearchTools(
   server: Pick<FastMCP<SessionData>, 'addTool'>,
   getClient: GetClient
 ): void {
+  if (targetsSelfHostedApi()) {
+    // Registering these against a self-hosted instance only surfaces tools
+    // that fail with a bare 404, so skip them and say why.
+    console.error(
+      'FIRECRAWL_API_URL points at a self-hosted instance — skipping the ' +
+        'cloud-only firecrawl_research_* tools (the research index only ' +
+        'exists on the Firecrawl cloud API).'
+    );
+    return;
+  }
+
   // --- search_papers ---
   server.addTool({
     name: 'firecrawl_research_search_papers',

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -659,6 +659,78 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.equal(stderr.includes('TypeError'), false, stderr);
 });
 
+// The five cloud-only wrappers over /v2/search/research/*. Self-hosted
+// instances have none of those routes, so the tools must not register there
+// (#341) while every other configuration keeps them.
+const RESEARCH_TOOLS = [
+  'firecrawl_research_search_papers',
+  'firecrawl_research_inspect_paper',
+  'firecrawl_research_related_papers',
+  'firecrawl_research_read_paper',
+  'firecrawl_research_search_github',
+];
+
+test('self-hosted FIRECRAWL_API_URL hides the cloud-only research tools', async (t) => {
+  const child = spawnServer({
+    CLOUD_SERVICE: '',
+    FIRECRAWL_API_KEY: 'fc-test',
+    // Self-hosted target; tools/list never contacts it.
+    FIRECRAWL_API_URL: 'http://127.0.0.1:4242',
+  });
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  t.after(() => stopChild(child));
+
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-self-hosted-research', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const tools = await client.request('tools/list');
+  const toolNames = tools.tools.map((tool) => tool.name);
+  for (const name of RESEARCH_TOOLS) {
+    assert.equal(toolNames.includes(name), false, `${name} must not register`);
+  }
+  assert.equal(
+    toolNames.some((name) => name.startsWith('firecrawl_research_')),
+    false
+  );
+  // The rest of the surface is untouched.
+  assert.ok(toolNames.includes('firecrawl_scrape'));
+  assert.ok(toolNames.includes('firecrawl_search'));
+  assert.match(stderr, /skipping the cloud-only firecrawl_research_\* tools/);
+});
+
+test('explicit cloud FIRECRAWL_API_URL keeps the research tools registered', async (t) => {
+  const child = spawnServer({
+    CLOUD_SERVICE: '',
+    FIRECRAWL_API_KEY: 'fc-test',
+    // Explicitly targeting the cloud (trailing slash exercises normalization)
+    // is not self-hosted.
+    FIRECRAWL_API_URL: 'https://api.firecrawl.dev/',
+  });
+  t.after(() => stopChild(child));
+
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-cloud-url-research', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const tools = await client.request('tools/list');
+  const toolNames = tools.tools.map((tool) => tool.name);
+  for (const name of RESEARCH_TOOLS) {
+    assert.ok(toolNames.includes(name), `${name} must stay registered`);
+  }
+});
+
 test('monitor create gives queries precedence over page targets', async (t) => {
   const fakeApi = await startFakeFirecrawlApi();
   t.after(() => fakeApi.close());


### PR DESCRIPTION
Fixes #341, reported by @inv-Eldho (same report as firecrawl/firecrawl#4166).

The five `firecrawl_research_*` tools wrap `/v2/search/research/*` endpoints that only exist on the cloud API, so on self-hosted Firecrawl every call returned a bare 404.

The fix skips registering those tools at startup when `FIRECRAWL_API_URL` points at a self-hosted instance (anything other than the trailing-slash-normalized cloud URL), logging a stderr notice in the same style as the existing keyless-mode notice. The `CLOUD_SERVICE === 'true'` exemption keeps the hosted deployment untouched, since it fronts a backend via the same env var (the existing search-profile tests pin that behavior).

Two new stdio smoke tests lock in the gating: tools absent + notice on self-hosted, present with an explicit cloud URL. The gating test fails without the fix. Suite: 61 passed, zero new failures; eslint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787939573&installation_model_id=11126&pr_number=342&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F342&signature=86d399b8eb5b54f0fc74596de9eb61b4df6e1d7936d4528c7f83b0d2855014a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip registering cloud-only research tools on self-hosted Firecrawl to avoid 404s when `FIRECRAWL_API_URL` points to a non-cloud instance. This keeps the tool list accurate and prevents broken calls.

- **Bug Fixes**
  - Added gating: if `FIRECRAWL_API_URL` (trimmed) is not `https://api.firecrawl.dev` and `CLOUD_SERVICE` is not `'true'`, do not register `firecrawl_research_*` tools. Write a clear stderr notice explaining why.
  - Added stdio smoke tests: self-hosted hides the tools and logs the notice; an explicit cloud URL keeps the tools registered.

<sup>Written for commit 9c94f495ed54b3d0c9e6b8d208d50723c9046ea8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

