### PR TITLE
docs: stop recommending API keys in MCP URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,27 @@ https://mcp.firecrawl.dev/v2/mcp
 
 On the keyless free tier, `scrape`, `search`, and `interact` work without an API key (rate-limited). Other tools such as `crawl`, `map`, `agent`, and `extract` still need a key.
 
-Prefer an API key or OAuth whenever the human can sign up. It unlocks the full tool set and higher limits. With a key, use:
+Prefer OAuth or an API key whenever the human can sign up. It unlocks the full tool set and higher limits.
+
+For an interactive account connection, use:
 
 ```
-https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp
+https://mcp.firecrawl.dev/v2/mcp-oauth
 ```
 
-See the [MCP server docs](https://docs.firecrawl.dev/mcp-server) and the [agent onboarding guide](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for setup details.
+For an API-key connection (for example, an unattended integration), keep the server URL as:
+
+```
+https://mcp.firecrawl.dev/v2/mcp
+```
+
+Then configure the client's secure header or secret setting with:
+
+```
+Authorization: Bearer <FIRECRAWL_API_KEY>
+```
+
+Never put an API key in the server URL. See the [hosted MCP setup guide](https://docs.firecrawl.dev/developer-guides/mcp-setup-guides/oauth) and the [agent onboarding guide](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for client-specific instructions.
 
 #### Search-only endpoint
 

--- a/tests/readme-security.test.mjs
+++ b/tests/readme-security.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+test('README documents hosted API-key setup without putting credentials in the URL', () => {
+  assert.doesNotMatch(
+    readme,
+    /https:\/\/mcp\.firecrawl\.dev\/\{FIRECRAWL_API_KEY\}\/v2\/mcp/i
+  );
+  assert.match(readme, /Authorization: Bearer <FIRECRAWL_API_KEY>/);
+  assert.match(readme, /Never put an API key in the server URL\./);
+});


### PR DESCRIPTION
## Summary
- replace the public README’s legacy key-in-path setup URL
- document OAuth for interactive setup and `Authorization: Bearer <FIRECRAWL_API_KEY>` for API-key integrations
- explicitly warn never to put an API key in the server URL
- add a README regression check

## Validation
- `npm run lint`
- `npm test` (66 passing)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788640764&installation_model_id=11126&pr_number=360&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F360&signature=0018507bec6736c8e9685ca9d65b0c59e6988de49f5fdfd4e075a7c0735c85cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated README to remove the legacy key-in-path example and clearly document OAuth for interactive setup and API-key usage via `Authorization: Bearer <FIRECRAWL_API_KEY>`. Added a README regression test to ensure credentials are never placed in the server URL.

<sup>Written for commit ce53dbf857ee2c90349e39c2e81305019c56d7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

