### PR TITLE
fix(mcp): Agent MCP keyless recovery prefers API key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -986,7 +986,7 @@ function recoveryPayload(
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
       code === 'CREDENTIAL_INVALID'
-        ? `The supplied Firecrawl credential is invalid or revoked. Reconnect the account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+        ? `The supplied Firecrawl credential is invalid or revoked. Create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
         : isQuotaExhausted
           ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue on this Agent MCP server now, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
           : isToolUnavailable
@@ -1003,30 +1003,22 @@ function recoveryPayload(
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
     next_actions: isKeylessEligibilityUnavailable
       ? [{ kind: 'retry_later', after_seconds: 30 }]
-      : code === 'CREDENTIAL_INVALID'
+      : isQuotaExhausted
         ? [
-            {
-              kind: 'connect_oauth',
-              url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
-            },
             { ...CONFIGURE_API_KEY_ACTION },
+            ...(retryLaterAction ? [retryLaterAction] : []),
           ]
-        : isQuotaExhausted
-          ? [
-              { ...CONFIGURE_API_KEY_ACTION },
-              ...(retryLaterAction ? [retryLaterAction] : []),
-            ]
-          : isKeylessAccessUnavailable
-            ? [{ ...CONFIGURE_API_KEY_ACTION }]
-            : isToolUnavailable
-              ? [
-                  {
-                    kind: 'continue_keyless',
-                    tools: [...KEYLESS_TOOL_NAMES],
-                  },
-                  { ...CONFIGURE_API_KEY_ACTION },
-                ]
-              : [{ ...CONFIGURE_API_KEY_ACTION }],
+        : isKeylessAccessUnavailable
+          ? [{ ...CONFIGURE_API_KEY_ACTION }]
+          : isToolUnavailable
+            ? [
+                {
+                  kind: 'continue_keyless',
+                  tools: [...KEYLESS_TOOL_NAMES],
+                },
+                { ...CONFIGURE_API_KEY_ACTION },
+              ]
+            : [{ ...CONFIGURE_API_KEY_ACTION }],
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -954,6 +954,16 @@ function isLocalKeylessStartup(): boolean {
   );
 }
 
+// Agent MCP (/v2/mcp) keyless recovery: same-URL upgrade is an API key.
+// retry_after_seconds / retry_later use the live TTL from eligibility or 429
+// when the API supplies one — never a hardcoded window.
+const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
+const CONFIGURE_API_KEY_ACTION = {
+  kind: 'configure_api_key',
+  header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
+  signup_url: API_KEY_SIGNUP_URL,
+} as const;
+
 function recoveryPayload(
   code: string,
   requestId: string = randomUUID(),
@@ -966,23 +976,26 @@ function recoveryPayload(
   const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
   const isKeylessEligibilityUnavailable =
     code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
-  const oauthUrl = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
+  const retryLaterAction =
+    typeof retryAfterSeconds === 'number' && retryAfterSeconds > 0
+      ? { kind: 'retry_later', after_seconds: retryAfterSeconds }
+      : undefined;
   return {
     code,
     request_id: requestId,
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
       code === 'CREDENTIAL_INVALID'
-        ? `The supplied Firecrawl credential is invalid or revoked. Reconnect the account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a new API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+        ? `The supplied Firecrawl credential is invalid or revoked. Create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
         : isQuotaExhausted
-          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now, connect a Firecrawl account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a free API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>.`
+          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue on this Agent MCP server now, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
           : isToolUnavailable
-            ? 'The free tier includes Search, Scrape, and Parse. This tool needs a connected account; Search, Scrape, and Parse still work, so no action is required.'
+            ? 'Agent MCP keyless includes Search, Scrape, and Parse. This tool needs an API key on this server. Search, Scrape, and Parse still work with no action required.'
             : isKeylessAccessUnavailable
-              ? `Anonymous keyless access is unavailable for this request. To continue, connect a Firecrawl account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a free API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>.`
+              ? `Anonymous keyless access is unavailable for this request. To continue on this Agent MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
-              : `This tool requires a Firecrawl account or API key. Connect an account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a free API key at https://www.firecrawl.dev/signin and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`,
+              : `This tool requires a Firecrawl API key. Create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`,
     ...(isKeylessAccessUnavailable
       ? {}
       : { available_tools: [...KEYLESS_TOOL_NAMES] }),
@@ -990,17 +1003,22 @@ function recoveryPayload(
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
     next_actions: isKeylessEligibilityUnavailable
       ? [{ kind: 'retry_later', after_seconds: 30 }]
-      : isQuotaExhausted || isKeylessAccessUnavailable
-      ? [
-          { kind: 'connect_oauth', url: oauthUrl, client_commands: [{ client: 'claude-code', command: 'claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth' }] },
-          { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
-        ]
-      : isToolUnavailable
-        ? [{ kind: 'continue_keyless', tools: [...KEYLESS_TOOL_NAMES] }]
-        : [
-            { kind: 'connect_oauth', url: oauthUrl },
-            { kind: 'configure_api_key', header: 'Authorization: Bearer <FIRECRAWL_API_KEY>' },
-          ],
+      : isQuotaExhausted
+        ? [
+            { ...CONFIGURE_API_KEY_ACTION },
+            ...(retryLaterAction ? [retryLaterAction] : []),
+          ]
+        : isKeylessAccessUnavailable
+          ? [{ ...CONFIGURE_API_KEY_ACTION }]
+          : isToolUnavailable
+            ? [
+                {
+                  kind: 'continue_keyless',
+                  tools: [...KEYLESS_TOOL_NAMES],
+                },
+                { ...CONFIGURE_API_KEY_ACTION },
+              ]
+            : [{ ...CONFIGURE_API_KEY_ACTION }],
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -988,11 +988,11 @@ function recoveryPayload(
       code === 'CREDENTIAL_INVALID'
         ? `The supplied Firecrawl credential is invalid or revoked. Create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
         : isQuotaExhausted
-          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue on this Agent MCP server now, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now on this MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
           : isToolUnavailable
             ? 'Agent MCP keyless includes Search, Scrape, and Parse. This tool needs an API key on this server. Search, Scrape, and Parse still work with no action required.'
             : isKeylessAccessUnavailable
-              ? `Anonymous keyless access is unavailable for this request. To continue on this Agent MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+              ? `Anonymous keyless access is unavailable for this request. To continue now on this MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
               : `This tool requires a Firecrawl API key. Create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -955,8 +955,9 @@ function isLocalKeylessStartup(): boolean {
 }
 
 // Agent MCP (/v2/mcp) keyless recovery: same-URL upgrade is an API key.
-// retry_after_seconds / retry_later use the live TTL from eligibility or 429
-// when the API supplies one — never a hardcoded window.
+// retry_after_seconds uses the live TTL from eligibility or 429 when the API
+// supplies one — never a hardcoded window. Wait is conveyed via that field and
+// the message, not a retry_later next_action on quota.
 const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
 const CONFIGURE_API_KEY_ACTION = {
   kind: 'configure_api_key',
@@ -976,10 +977,6 @@ function recoveryPayload(
   const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
   const isKeylessEligibilityUnavailable =
     code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
-  const retryLaterAction =
-    typeof retryAfterSeconds === 'number' && retryAfterSeconds > 0
-      ? { kind: 'retry_later', after_seconds: retryAfterSeconds }
-      : undefined;
   return {
     code,
     request_id: requestId,
@@ -1004,10 +1001,7 @@ function recoveryPayload(
     next_actions: isKeylessEligibilityUnavailable
       ? [{ kind: 'retry_later', after_seconds: 30 }]
       : isQuotaExhausted
-        ? [
-            { ...CONFIGURE_API_KEY_ACTION },
-            ...(retryLaterAction ? [retryLaterAction] : []),
-          ]
+        ? [{ ...CONFIGURE_API_KEY_ACTION }]
         : isKeylessAccessUnavailable
           ? [{ ...CONFIGURE_API_KEY_ACTION }]
           : isToolUnavailable

--- a/src/index.ts
+++ b/src/index.ts
@@ -954,16 +954,27 @@ function isLocalKeylessStartup(): boolean {
   );
 }
 
-// Agent MCP (/v2/mcp) keyless recovery: same-URL upgrade is an API key.
+// Agent MCP (/v2/mcp) keyless recovery: same-URL API key first; OAuth is an
+// opt-in alternate (requires_user_consent) via /v2/mcp-oauth.
 // retry_after_seconds uses the live TTL from eligibility or 429 when the API
 // supplies one — never a hardcoded window. Wait is conveyed via that field and
 // the message, not a retry_later next_action on quota.
 const API_KEY_SIGNUP_URL = 'https://www.firecrawl.dev/app/api-keys';
+const MCP_OAUTH_URL = 'https://mcp.firecrawl.dev/v2/mcp-oauth';
 const CONFIGURE_API_KEY_ACTION = {
   kind: 'configure_api_key',
   header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
   signup_url: API_KEY_SIGNUP_URL,
 } as const;
+const CONNECT_OAUTH_ACTION = {
+  kind: 'connect_oauth',
+  url: MCP_OAUTH_URL,
+  requires_user_consent: true,
+} as const;
+const AUTH_UPGRADE_ACTIONS = [
+  { ...CONFIGURE_API_KEY_ACTION },
+  { ...CONNECT_OAUTH_ACTION },
+] as const;
 
 function recoveryPayload(
   code: string,
@@ -983,16 +994,16 @@ function recoveryPayload(
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
       code === 'CREDENTIAL_INVALID'
-        ? `The supplied Firecrawl credential is invalid or revoked. Create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+        ? `The supplied Firecrawl credential is invalid or revoked. Create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry. Or ask before switching this server to ${MCP_OAUTH_URL}.`
         : isQuotaExhausted
-          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now on this MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+          ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue now on this MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry. Or ask before switching this server to ${MCP_OAUTH_URL}.`
           : isToolUnavailable
             ? 'Agent MCP keyless includes Search, Scrape, and Parse. This tool needs an API key on this server. Search, Scrape, and Parse still work with no action required.'
             : isKeylessAccessUnavailable
-              ? `Anonymous keyless access is unavailable for this request. To continue now on this MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+              ? `Anonymous keyless access is unavailable for this request. To continue now on this MCP server, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry. Or ask before switching this server to ${MCP_OAUTH_URL}.`
               : isKeylessEligibilityUnavailable
                 ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
-              : `This tool requires a Firecrawl API key. Create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`,
+              : `This tool requires a Firecrawl API key. Create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry. Or ask before switching this server to ${MCP_OAUTH_URL}.`,
     ...(isKeylessAccessUnavailable
       ? {}
       : { available_tools: [...KEYLESS_TOOL_NAMES] }),
@@ -1001,18 +1012,18 @@ function recoveryPayload(
     next_actions: isKeylessEligibilityUnavailable
       ? [{ kind: 'retry_later', after_seconds: 30 }]
       : isQuotaExhausted
-        ? [{ ...CONFIGURE_API_KEY_ACTION }]
+        ? [...AUTH_UPGRADE_ACTIONS]
         : isKeylessAccessUnavailable
-          ? [{ ...CONFIGURE_API_KEY_ACTION }]
+          ? [...AUTH_UPGRADE_ACTIONS]
           : isToolUnavailable
             ? [
                 {
                   kind: 'continue_keyless',
                   tools: [...KEYLESS_TOOL_NAMES],
                 },
-                { ...CONFIGURE_API_KEY_ACTION },
+                ...AUTH_UPGRADE_ACTIONS,
               ]
-            : [{ ...CONFIGURE_API_KEY_ACTION }],
+            : [...AUTH_UPGRADE_ACTIONS],
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -986,7 +986,7 @@ function recoveryPayload(
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
       code === 'CREDENTIAL_INVALID'
-        ? `The supplied Firecrawl credential is invalid or revoked. Create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
+        ? `The supplied Firecrawl credential is invalid or revoked. Reconnect the account via OAuth (https://mcp.firecrawl.dev/v2/mcp-oauth) or create a new API key at ${API_KEY_SIGNUP_URL} and send it as Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
         : isQuotaExhausted
           ? `The free daily limit for this network has been reached${retryAfterSeconds ? `; try again in about ${retryAfterSeconds} seconds` : ''}. To continue on this Agent MCP server now, create a free API key at ${API_KEY_SIGNUP_URL} and set Authorization: Bearer <FIRECRAWL_API_KEY>, then retry.`
           : isToolUnavailable
@@ -1003,22 +1003,30 @@ function recoveryPayload(
     ...(retryAfterSeconds ? { retry_after_seconds: retryAfterSeconds } : {}),
     next_actions: isKeylessEligibilityUnavailable
       ? [{ kind: 'retry_later', after_seconds: 30 }]
-      : isQuotaExhausted
+      : code === 'CREDENTIAL_INVALID'
         ? [
+            {
+              kind: 'connect_oauth',
+              url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+            },
             { ...CONFIGURE_API_KEY_ACTION },
-            ...(retryLaterAction ? [retryLaterAction] : []),
           ]
-        : isKeylessAccessUnavailable
-          ? [{ ...CONFIGURE_API_KEY_ACTION }]
-          : isToolUnavailable
-            ? [
-                {
-                  kind: 'continue_keyless',
-                  tools: [...KEYLESS_TOOL_NAMES],
-                },
-                { ...CONFIGURE_API_KEY_ACTION },
-              ]
-            : [{ ...CONFIGURE_API_KEY_ACTION }],
+        : isQuotaExhausted
+          ? [
+              { ...CONFIGURE_API_KEY_ACTION },
+              ...(retryLaterAction ? [retryLaterAction] : []),
+            ]
+          : isKeylessAccessUnavailable
+            ? [{ ...CONFIGURE_API_KEY_ACTION }]
+            : isToolUnavailable
+              ? [
+                  {
+                    kind: 'continue_keyless',
+                    tools: [...KEYLESS_TOOL_NAMES],
+                  },
+                  { ...CONFIGURE_API_KEY_ACTION },
+                ]
+              : [{ ...CONFIGURE_API_KEY_ACTION }],
   };
 }
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1162,10 +1162,13 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
     );
     if (label === 'with-reason') {
       assert.equal(result.structuredContent.retry_after_seconds, 42);
-      assert.deepEqual(result.structuredContent.next_actions[1], {
-        kind: 'retry_later',
-        after_seconds: 42,
-      });
+      assert.deepEqual(result.structuredContent.next_actions, [
+        {
+          kind: 'configure_api_key',
+          header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
+          signup_url: 'https://www.firecrawl.dev/app/api-keys',
+        },
+      ], label);
       assert.match(
         result.structuredContent.message,
         /about 42 seconds/,
@@ -1173,7 +1176,13 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
       );
     } else {
       assert.equal(result.structuredContent.retry_after_seconds, undefined, label);
-      assert.equal(result.structuredContent.next_actions.length, 1, label);
+      assert.deepEqual(result.structuredContent.next_actions, [
+        {
+          kind: 'configure_api_key',
+          header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
+          signup_url: 'https://www.firecrawl.dev/app/api-keys',
+        },
+      ], label);
     }
     await cleanup();
   }

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1097,6 +1097,11 @@ test('HTTP cloud keyless continues with free-tier tools when an account-only too
       header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
       signup_url: 'https://www.firecrawl.dev/app/api-keys',
     },
+    {
+      kind: 'connect_oauth',
+      url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+      requires_user_consent: true,
+    },
   ]);
   assert.match(
     result.structuredContent.message,
@@ -1160,15 +1165,25 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
       /To continue now on this MCP server/,
       label
     );
+    assert.match(
+      result.structuredContent.message,
+      /ask before switching this server to https:\/\/mcp\.firecrawl\.dev\/v2\/mcp-oauth/,
+      label
+    );
+    assert.deepEqual(result.structuredContent.next_actions, [
+      {
+        kind: 'configure_api_key',
+        header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
+        signup_url: 'https://www.firecrawl.dev/app/api-keys',
+      },
+      {
+        kind: 'connect_oauth',
+        url: 'https://mcp.firecrawl.dev/v2/mcp-oauth',
+        requires_user_consent: true,
+      },
+    ], label);
     if (label === 'with-reason') {
       assert.equal(result.structuredContent.retry_after_seconds, 42);
-      assert.deepEqual(result.structuredContent.next_actions, [
-        {
-          kind: 'configure_api_key',
-          header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
-          signup_url: 'https://www.firecrawl.dev/app/api-keys',
-        },
-      ], label);
       assert.match(
         result.structuredContent.message,
         /about 42 seconds/,
@@ -1176,13 +1191,6 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
       );
     } else {
       assert.equal(result.structuredContent.retry_after_seconds, undefined, label);
-      assert.deepEqual(result.structuredContent.next_actions, [
-        {
-          kind: 'configure_api_key',
-          header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
-          signup_url: 'https://www.firecrawl.dev/app/api-keys',
-        },
-      ], label);
     }
     await cleanup();
   }

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1157,7 +1157,7 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
     );
     assert.match(
       result.structuredContent.message,
-      /Agent MCP server/,
+      /To continue now on this MCP server/,
       label
     );
     if (label === 'with-reason') {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1092,7 +1092,16 @@ test('HTTP cloud keyless continues with free-tier tools when an account-only too
       kind: 'continue_keyless',
       tools: ['firecrawl_scrape', 'firecrawl_search', 'firecrawl_parse'],
     },
+    {
+      kind: 'configure_api_key',
+      header: 'Authorization: Bearer <FIRECRAWL_API_KEY>',
+      signup_url: 'https://www.firecrawl.dev/app/api-keys',
+    },
   ]);
+  assert.match(
+    result.structuredContent.message,
+    /Agent MCP keyless includes Search, Scrape, and Parse/
+  );
   assert.deepEqual(result.structuredContent.available_tools, [
     'firecrawl_scrape',
     'firecrawl_search',
@@ -1136,8 +1145,36 @@ test('HTTP cloud keyless keeps 429 recovery structured during API deploy skew', 
     const result = parseSseJson(await response.text()).result;
     assert.equal(result.isError, true, label);
     assert.equal(result.structuredContent.code, expectedCode, label);
-    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', label);
-    if (label === 'with-reason') assert.equal(result.structuredContent.retry_after_seconds, 42);
+    assert.equal(
+      result.structuredContent.next_actions[0].kind,
+      'configure_api_key',
+      label
+    );
+    assert.equal(
+      result.structuredContent.next_actions[0].signup_url,
+      'https://www.firecrawl.dev/app/api-keys',
+      label
+    );
+    assert.match(
+      result.structuredContent.message,
+      /Agent MCP server/,
+      label
+    );
+    if (label === 'with-reason') {
+      assert.equal(result.structuredContent.retry_after_seconds, 42);
+      assert.deepEqual(result.structuredContent.next_actions[1], {
+        kind: 'retry_later',
+        after_seconds: 42,
+      });
+      assert.match(
+        result.structuredContent.message,
+        /about 42 seconds/,
+        label
+      );
+    } else {
+      assert.equal(result.structuredContent.retry_after_seconds, undefined, label);
+      assert.equal(result.structuredContent.next_actions.length, 1, label);
+    }
     await cleanup();
   }
 });
@@ -1300,7 +1337,7 @@ test('HTTP cloud keyless rejects multi-hop or malformed forwarded IP identity', 
     const result = parseSseJson(await response.text()).result;
     assert.equal(result.isError, true, xff);
     assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE', xff);
-    assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth', xff);
+    assert.equal(result.structuredContent.next_actions[0].kind, 'configure_api_key', xff);
     assert.equal(result.structuredContent.available_tools, undefined, xff);
   }
   assert.equal(backend.requests.length, 0, JSON.stringify(backend.requests));
@@ -1453,7 +1490,7 @@ test('HTTP cloud transport returns recovery when keyless identity has no client 
   const result = parseSseJson(await toolCall.text()).result;
   assert.equal(result.isError, true);
   assert.equal(result.structuredContent.code, 'KEYLESS_ACCESS_NOT_AVAILABLE');
-  assert.equal(result.structuredContent.next_actions[0].kind, 'connect_oauth');
+  assert.equal(result.structuredContent.next_actions[0].kind, 'configure_api_key');
   assert.equal(result.structuredContent.available_tools, undefined);
   assertServerGeneratedRequestId(result.structuredContent, [
     'client-json-rpc-id',


### PR DESCRIPTION
## Why
Agent MCP (`/v2/mcp`) same-URL upgrade is an API key. Soft-limit recovery was leading with OAuth / `claude mcp add …/mcp-oauth`, which is unreliable mid-session and fights the Agent vs Human MCP split.

## Summary
- Keyless quota / limit / access recovery leads with `configure_api_key` + `signup_url`
- `retry_after_seconds` and `retry_later` use the live TTL from eligibility/429 when present (not a hardcoded 3600)
- Account-only tools while keyless return `continue_keyless` plus optional API-key upgrade
- Drop OAuth-first `next_actions` / client_commands from Agent MCP keyless recovery

## Test plan
- [x] `npm test -- --test-name-pattern='keyless'` (66 passing)
- [ ] Confirm quota message interpolates real `retry_after_seconds` when eligibility/429 returns a TTL
- [ ] Confirm account-only tool (e.g. crawl) still offers Search/Scrape/Parse continue path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-mcp-server/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788737391&installation_model_id=11126&pr_number=362&repository=firecrawl%2Ffirecrawl-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-mcp-server%2Fpull%2F362&signature=1907aaf4f0161a47d6aab09e5c6ef3a938cf5531d2fb3a1c2a4f9a6bb8a2447d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent MCP keyless recovery now leads with API key setup and adds a consented OAuth option as a secondary path. Responses use live TTLs and clearer copy.

- **Bug Fixes**
  - Start `next_actions` with `configure_api_key` (includes `signup_url` `https://www.firecrawl.dev/app/api-keys`), then `connect_oauth` with `requires_user_consent: true`.
  - Use dynamic `retry_after_seconds`; remove `retry_later` for quota/429.
  - For account-only tools while keyless, return `continue_keyless` plus the API key and OAuth options.
  - Update messages: “continue now on this MCP server” and an ask-before-switch note to `https://mcp.firecrawl.dev/v2/mcp-oauth`; tighten free-tier tool wording.

<sup>Written for commit 749ee8aef0a1495457157adef26e737131de40ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

