### PR TITLE
release: 3.23.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl-mcp",
-  "version": "3.23.8",
+  "version": "3.23.9",
   "description": "MCP server for Firecrawl — search, scrape, and interact with the web. Supports both cloud and self-hosted instances. Features include web search, scraping, page interaction, batch processing, and LLM-powered content analysis.",
   "type": "module",
   "mcpName": "io.github.firecrawl/firecrawl-mcp-server",


### PR DESCRIPTION
Bump the version to 3.23.9.

The publish workflow runs on a main push that touches `package.json`. This bump releases #366 (tolerance for the removal of internal developer-search response fields) to npm.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `firecrawl-mcp` 3.23.9 to publish tolerance for missing internal developer-search response fields, keeping clients compatible when those fields are removed. Only the version in `package.json` was updated.

<sup>Written for commit c170452e2ce508b991678b9d683c176074c0a5e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

