### PR TITLE
fix(annotations): align firecrawl_search readOnlyHint with scrapeOptions.actions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2115,7 +2115,7 @@ server.addTool({
   name: 'firecrawl_search',
   annotations: {
     title: 'Search the web',
-    readOnlyHint: true, // Runs a web search and returns results; does not modify external sites.
+    readOnlyHint: false, // scrapeOptions.actions can drive clicks, form input, and scripts on visited pages.
     openWorldHint: true, // Searches the open web across arbitrary domains and sources.
     destructiveHint: false, // Query-only; no destructive side effects on external entities.
   },

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -709,6 +709,11 @@ test('primary search profile uses the strict marketplace search tool, not the fu
   const tools = await listToolDefinitions(port, SEARCH_ENDPOINT, headers);
   const search = tools.find((tool) => tool.name === 'firecrawl_search');
   assert.ok(search, 'primary profile must register firecrawl_search');
+  assert.equal(
+    search.annotations?.readOnlyHint,
+    true,
+    'search-profile firecrawl_search has no scrapeOptions.actions and stays read-only'
+  );
   assert.doesNotMatch(JSON.stringify(search.inputSchema), /scrapeOptions/);
   assert.doesNotMatch(search.description ?? '', /search_feedback|refund/i);
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -744,6 +744,11 @@ test('local keyless stdio omits feedback tools and qualifies search-feedback IDs
   assert.equal(toolNames.includes('firecrawl_feedback'), false);
   const search = tools.tools.find((tool) => tool.name === 'firecrawl_search');
   assert.ok(search);
+  assert.equal(
+    search.annotations?.readOnlyHint,
+    false,
+    'firecrawl_search accepts scrapeOptions.actions and must not claim readOnlyHint'
+  );
   assert.match(
     search.description,
     /authenticated responses can include an `id` for optional search feedback/i


### PR DESCRIPTION
## Summary

Set `readOnlyHint: false` on the full-surface `firecrawl_search` tool because it accepts `scrapeOptions.actions` (click, write, executeJavascript) that can mutate pages visited during search result scraping.

## Motivation

Fixes #311

MCP clients that honor `readOnlyHint: true` may skip confirmation prompts for tools that can drive browser interactions. The full `firecrawl_search` schema includes `scrapeOptions.actions`, but the annotation claimed read-only — inconsistent with `firecrawl_scrape` and other tools that expose the same action surface.

## Changes

- Change `readOnlyHint` from `true` to `false` on the main `firecrawl_search` registration in `src/index.ts`
- Leave the search-profile `firecrawl_search` variant at `readOnlyHint: true` (it rejects `scrapeOptions` via a strict schema)
- Add regression assertions in `tests/mcp-smoke.test.mjs` and `tests/mcp-search-profile.test.mjs`

## Tests

```bash
npm run build
node --test tests/mcp-smoke.test.mjs -t "local keyless stdio"
node --test tests/mcp-search-profile.test.mjs
```

- `local keyless stdio omits feedback tools...` — passes, asserts full-surface `readOnlyHint === false`
- All 22 `mcp-search-profile` tests — pass, including search-profile `readOnlyHint === true`

Note: three pre-existing failures in `mcp-smoke.test.mjs` on this environment (keyless tool filtering / deprecated extract registration) are unrelated to this change.

## Notes

- Reviewed with composer-2.5: **APPROVE**
- Optional follow-up: mirror `firecrawl_scrape` by using `readOnlyHint: SAFE_MODE` when cloud safe mode strips `actions` from the schema

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `firecrawl_search` annotation with its behavior by setting readOnlyHint to false when the tool accepts `scrapeOptions.actions`. Previously it claimed read-only, which let MCP clients skip confirmation for actions that can mutate visited pages.

- Change: Update `src/index.ts` to set readOnlyHint: false for the full-surface `firecrawl_search`. Keep the search-profile variant at readOnlyHint: true because its schema rejects `scrapeOptions`.
- Tests: Add assertions in `tests/mcp-smoke.test.mjs` (expects false) and `tests/mcp-search-profile.test.mjs` (expects true) to prevent regressions.
- Impact: No schema/API changes. MCP clients may now prompt for confirmation when using the full-surface tool. No migration required.

<sup>Written for commit 9e53c85a56343ebb8a62cd689ded6d995a8f4e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

