### PR TITLE
docs(readme): align scrape JSON format example with jsonOptions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,21 +354,19 @@ Scrape content from a single URL with advanced options.
   "name": "firecrawl_scrape",
   "arguments": {
     "url": "https://example.com/product",
-    "formats": [
-      {
-        "type": "json",
-        "prompt": "Extract the product information",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "name": { "type": "string" },
-            "price": { "type": "number" },
-            "description": { "type": "string" }
-          },
-          "required": ["name", "price"]
-        }
+    "formats": ["json"],
+    "jsonOptions": {
+      "prompt": "Extract the product information",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "price": { "type": "number" },
+          "description": { "type": "string" }
+        },
+        "required": ["name", "price"]
       }
-    ]
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary

Fix the `firecrawl_scrape` tool section JSON example so it uses `formats: ["json"]` with `prompt` and `schema` in `jsonOptions`, matching the MCP tool schema and `src/index.ts`.

## Motivation

Fixes #357. The scrape tool section showed an object inside `formats`, which the MCP server rejects with a `-32602` validation error. New users copying the "preferred" JSON example hit this immediately. The keyless tier sentence on `main` already lists `scrape`, `search`, and `parse` (not `interact`).

## Changes

- Update the scrape tool **Usage Example (JSON format - preferred)** to use `formats: ["json"]` + `jsonOptions` instead of an object in `formats`.
- No code changes; section 7 ("Structured data with Scrape JSON") already showed the correct shape.

## Tests

- Docs-only change; no build or test commands required.
- Verified README grep: no remaining object-in-`formats` examples; branding and search `scrapeOptions` already use string format arrays.

## Notes

- composer-2.5 review: APPROVE
- Minimal diff focused on the first example users are told to copy.

Fixes #357

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README example for `firecrawl_scrape` to use `formats: ["json"]` with `jsonOptions` (`prompt`, `schema`). This matches the tool API and avoids MCP `-32602` validation errors when users copy the example.

- **Migration**
  - If you copied the previous example, change `formats` from an object to an array and move `prompt` and `schema` into `jsonOptions`.

<sup>Written for commit 019894317b9a052eff68ef6e6a6e467938776f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

