### PR TITLE
fix(mcp): publish satisfiable inputSchemas for free-form JSON fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,11 @@ import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { z } from 'zod';
 import { registerDeveloperTools } from './developer';
+import {
+  mcpJsonObjectOptional,
+  mcpJsonSchemaDocumentOptional,
+  mcpStringMapOptional,
+} from './mcp-json-schemas';
 import { extractSingleTrustedClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
 import { registerResearchTools } from './research';
@@ -1518,7 +1523,7 @@ const scrapeParamsSchema = z.object({
   jsonOptions: z
     .object({
       prompt: z.string().optional(),
-      schema: z.record(z.string(), z.any()).optional(),
+      schema: mcpJsonSchemaDocumentOptional,
     })
     .optional(),
   queryOptions: z
@@ -1602,7 +1607,7 @@ const parseOptionParamsSchema = z.object({
   jsonOptions: z
     .object({
       prompt: z.string().optional(),
-      schema: z.record(z.string(), z.any()).optional(),
+      schema: mcpJsonSchemaDocumentOptional,
     })
     .optional(),
   queryOptions: z
@@ -2541,7 +2546,7 @@ Returns submission status, feedback ID, and accounting fields.
       querySuggestions: z.string().max(2000).optional(),
       url: z.string().url().optional(),
       pageNumbers: z.array(z.number().int().positive()).max(100).optional(),
-      metadata: z.record(z.string(), z.unknown()).optional(),
+      metadata: mcpJsonObjectOptional,
     }),
     execute: async (args: unknown, { session, log }): Promise<string> => {
       const {
@@ -2664,7 +2669,7 @@ Crawl results can be large; use conservative limits when full-site coverage is u
       ? {}
       : {
           webhook: z.string().optional(),
-          webhookHeaders: z.record(z.string(), z.string()).optional(),
+          webhookHeaders: mcpStringMapOptional,
         }),
     deduplicateSimilarURLs: z.boolean().optional(),
     ignoreQueryParameters: z.boolean().optional(),
@@ -2754,7 +2759,7 @@ Deprecated compatibility entry point. Use firecrawl_scrape once per known URL wi
   parameters: z.object({
     urls: z.array(z.string()),
     prompt: z.string().optional(),
-    schema: z.record(z.string(), z.any()).optional(),
+    schema: mcpJsonSchemaDocumentOptional,
     allowExternalLinks: z.boolean().optional(),
     enableWebSearch: z.boolean().optional(),
     includeSubdomains: z.boolean().optional(),
@@ -2790,7 +2795,7 @@ This call returns only a job ID, not the research result. Read the job with \`fi
   parameters: z.object({
     prompt: z.string().min(1).max(10000),
     urls: z.array(z.string().url()).optional(),
-    schema: z.record(z.string(), z.any()).optional(),
+    schema: mcpJsonSchemaDocumentOptional,
   }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
     const client = getClient(session);

--- a/src/mcp-json-schemas.ts
+++ b/src/mcp-json-schemas.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Arbitrary JSON object for MCP tool parameters.
+ *
+ * Avoid z.record(): fastmcp's strictJsonSchema turns it into an unsatisfiable
+ * object schema (propertyNames + additionalProperties: false, no properties).
+ */
+export const mcpJsonObject = z.json().refine(isJsonObject, {
+  message: 'Expected a JSON object',
+});
+
+export const mcpJsonObjectOptional = mcpJsonObject.optional();
+
+/** JSON object whose values are all strings (e.g. webhook header maps). */
+export const mcpStringMapOptional = z
+  .json()
+  .refine(
+    (value) =>
+      isJsonObject(value) &&
+      Object.values(value).every((entry) => typeof entry === 'string'),
+    { message: 'Expected an object with string values' }
+  )
+  .optional();
+
+/** JSON Schema document for scrape/agent jsonOptions.schema. */
+export const mcpJsonSchemaDocumentOptional = mcpJsonObjectOptional;

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -11,6 +11,7 @@
 
 import { z } from 'zod';
 import type { FastMCP } from 'fastmcp';
+import { mcpJsonObject, mcpJsonObjectOptional } from './mcp-json-schemas';
 import {
   credentialForOutboundRequest,
   type CredentialSession,
@@ -229,7 +230,7 @@ Create a recurring scrape, crawl, or search monitor that compares each check wit
 In the simple form, a \`goal\` is required. If \`queries\` contains one or more non-empty values and is supplied with \`page\`/\`pages\`, \`queries\` create the search target and page targets are ignored. A monitor schedules future network checks and can send configured email or webhook notifications. Returns the created monitor.
 `,
     parameters: z.object({
-      body: z.record(z.string(), z.any()).optional(),
+      body: mcpJsonObjectOptional,
       page: z.string().optional(),
       pages: z.array(z.string()).optional(),
       queries: z.array(z.string()).optional(),
@@ -317,7 +318,7 @@ Returns the updated monitor.
 `,
     parameters: z.object({
       id: z.string(),
-      body: z.record(z.string(), z.any()),
+      body: mcpJsonObject,
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { id, body } = args as {

--- a/tests/mcp-input-schema.test.mjs
+++ b/tests/mcp-input-schema.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import test from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
+
+function isUnsatisfiableFreeFormObject(schema) {
+  return (
+    schema?.type === 'object' &&
+    schema?.additionalProperties === false &&
+    !schema?.properties &&
+    schema?.propertyNames?.type === 'string'
+  );
+}
+
+async function listToolsViaStdio() {
+  const child = spawn('node', ['dist/index.js'], {
+    env: { ...process.env, FIRECRAWL_API_KEY: 'fc-test' },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+
+  const messages = [
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'schema-probe', version: '0.0.0' },
+      },
+    },
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+  ];
+
+  for (const message of messages) {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  await delay(2500);
+  child.kill();
+
+  for (const line of stdout.split('\n').filter(Boolean)) {
+    try {
+      const payload = JSON.parse(line);
+      if (payload.id === 2) {
+        return payload.result.tools;
+      }
+    } catch {
+      // ignore non-json lines
+    }
+  }
+
+  throw new Error('tools/list response not found');
+}
+
+test('published scrape jsonOptions.schema accepts real JSON Schema objects', async () => {
+  const tools = await listToolsViaStdio();
+  const scrape = tools.find((tool) => tool.name === 'firecrawl_scrape');
+  assert.ok(scrape, 'firecrawl_scrape missing from tools/list');
+
+  const schemaField = scrape.inputSchema.properties.jsonOptions.properties.schema;
+  assert.equal(isUnsatisfiableFreeFormObject(schemaField), false);
+  assert.ok(
+    schemaField.allOf?.[0]?.$ref ||
+      schemaField.additionalProperties !== false,
+    'schema field should admit arbitrary JSON Schema keys'
+  );
+
+  const agent = tools.find((tool) => tool.name === 'firecrawl_agent');
+  assert.ok(agent, 'firecrawl_agent missing from tools/list');
+  const agentSchemaField = agent.inputSchema.properties.schema;
+  assert.equal(isUnsatisfiableFreeFormObject(agentSchemaField), false);
+});


### PR DESCRIPTION
## Summary

Replace `z.record()` tool-parameter schemas with `z.json()`-based helpers so fastmcp's `strictJsonSchema` no longer publishes unsatisfiable object schemas (`propertyNames` + `additionalProperties: false` with no `properties`).

## Motivation

`firecrawl_scrape`'s published `jsonOptions.schema` rejected every legitimate JSON Schema document in MCP clients that validate tool arguments against `tools/list` inputSchemas before forwarding calls. The server accepted these calls at runtime, but schema-validating gateways saw 100% failure for JSON extraction with a schema.

Fixes #373

## Changes

- Add `src/mcp-json-schemas.ts` with shared helpers (`mcpJsonObject`, `mcpStringMapOptional`, etc.)
- Use helpers for `jsonOptions.schema`, agent `schema`, feedback `metadata`, crawl `webhookHeaders`, and monitor `body` fields
- Add regression test asserting scrape/agent schema fields are satisfiable via stdio `tools/list`

## Tests

- `npm run build` — pass
- `npm run lint` — pass
- `npm test` — 69/72 pass; 3 pre-existing flaky smoke/OAuth tests fail in this environment (unrelated to this change)
- `node --test tests/mcp-input-schema.test.mjs` — pass

## Notes

Runtime validation behavior is preserved: object-only refinements still reject arrays/null for body/metadata/schema fields, and `webhookHeaders` still requires string values at execution time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes satisfiable MCP inputSchemas for free‑form JSON parameters so schema‑validating clients accept real payloads. Previously `z.record()` generated unsatisfiable object schemas under `fastmcp`’s `strictJsonSchema`; now `z.json()`-based helpers describe permissive JSON objects.

- Replace `z.record()` with helpers from `src/mcp-json-schemas.ts` (`mcpJsonObject`, `mcpJsonObjectOptional`, `mcpStringMapOptional`, `mcpJsonSchemaDocumentOptional`).
- Affects: `firecrawl_scrape` `jsonOptions.schema`, agent `schema`, feedback `metadata`, crawl `webhookHeaders`, and monitor `body`.
- Add `tests/mcp-input-schema.test.mjs` to assert `tools/list` publishes satisfiable schemas via stdio.
- No caller changes required; runtime validation is unchanged (object-only fields still reject arrays/null; `webhookHeaders` still requires string values).

<sup>Written for commit a46eab09ff85dbdffa3cf63d1e532d4a3a7b4491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecrawl/firecrawl-mcp-server/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

