### PR TITLE
feat: agent usability — bounded outputs, structured errors, complete tool schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mendable/firecrawl-js": "4.25.2",
     "dotenv": "^17.2.2",
     "fastmcp": "4.3.2",
-    "zod": "^4.1.5"
+    "zod": "4.1.13"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  zod: 4.1.13
+
 patchedDependencies:
-  fastmcp@4.3.2:
-    hash: 4ce43b72d62ea76fc9a1cc3a6244a4258d3311a6d369cbe171b5186b3139b489
-    path: patches/fastmcp@4.3.2.patch
+  fastmcp@4.3.2: 4ce43b72d62ea76fc9a1cc3a6244a4258d3311a6d369cbe171b5186b3139b489
 
 importers:
 
@@ -268,7 +269,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: 4.1.13
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -1677,7 +1678,7 @@ packages:
       arktype: ^2.1.20
       effect: ^3.16.0
       sury: ^10.0.0
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
       zod-to-json-schema: ^3.25.0
     peerDependenciesMeta:
       '@valibot/to-json-schema':
@@ -1716,24 +1717,15 @@ packages:
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
-      zod: ^3.24.1
+      zod: 4.1.13
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25.28 || ^4
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.1.11:
-    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+      zod: 4.1.13
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
-
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1875,13 +1867,13 @@ snapshots:
       axios: 1.16.1(debug@4.4.3)
       firecrawl: 4.16.0
       typescript-event-target: 1.1.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod: 4.1.13
+      zod-to-json-schema: 3.24.6(zod@4.1.13)
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.1.13)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.20.0
@@ -1898,8 +1890,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.2(zod@4.1.13)
     transitivePeerDependencies:
       - supports-color
 
@@ -2519,7 +2511,7 @@ snapshots:
 
   fastmcp@4.3.2(patch_hash=4ce43b72d62ea76fc9a1cc3a6244a4258d3311a6d369cbe171b5186b3139b489):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.1.13)
       '@standard-schema/spec': 1.0.0
       execa: 9.6.1
       file-type: 21.3.4
@@ -2529,10 +2521,10 @@ snapshots:
       strict-event-emitter-types: 2.0.0
       undici: 7.28.0
       uri-templates: 0.2.0
-      xsschema: 0.4.4(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+      xsschema: 0.4.4(zod-to-json-schema@3.25.2(zod@4.1.13))(zod@4.1.13)
       yargs: 18.0.0
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.2(zod@4.1.13)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@valibot/to-json-schema'
@@ -2586,8 +2578,8 @@ snapshots:
     dependencies:
       axios: 1.15.2
       typescript-event-target: 1.1.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod: 4.1.13
+      zod-to-json-schema: 3.24.6(zod@4.1.13)
     transitivePeerDependencies:
       - debug
 
@@ -3361,10 +3353,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  xsschema@0.4.4(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3):
+  xsschema@0.4.4(zod-to-json-schema@3.25.2(zod@4.1.13))(zod@4.1.13):
     optionalDependencies:
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.2(zod@4.1.13)
 
   y18n@5.0.8: {}
 
@@ -3383,18 +3375,12 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.24.6(zod@3.25.76):
+  zod-to-json-schema@3.24.6(zod@4.1.13):
     dependencies:
-      zod: 3.25.76
+      zod: 4.1.13
 
-  zod-to-json-schema@3.25.2(zod@4.4.3):
+  zod-to-json-schema@3.25.2(zod@4.1.13):
     dependencies:
-      zod: 4.4.3
-
-  zod@3.25.76: {}
-
-  zod@4.1.11: {}
+      zod: 4.1.13
 
   zod@4.1.13: {}
-
-  zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: 4.3.2
         version: 4.3.2(patch_hash=4ce43b72d62ea76fc9a1cc3a6244a4258d3311a6d369cbe171b5186b3139b489)
       zod:
-        specifier: ^4.1.5
-        version: 4.1.11
+        specifier: 4.1.13
+        version: 4.1.13
     devDependencies:
       '@types/node':
         specifier: ^24.3.1
@@ -1729,6 +1729,9 @@ packages:
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
+  zod@4.1.13:
+    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3391,5 +3394,7 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.1.11: {}
+
+  zod@4.1.13: {}
 
   zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,8 @@ allowBuilds:
   esbuild: true
   tldjs: true
 
+overrides:
+  zod: 4.1.13
+
 patchedDependencies:
   fastmcp@4.3.2: patches/fastmcp@4.3.2.patch

--- a/src/developer.ts
+++ b/src/developer.ts
@@ -12,30 +12,19 @@
 
 import { z } from 'zod';
 import type { FastMCP } from 'fastmcp';
+import {
+  type ClientLike,
+  type GetClient,
+  ORIGIN_HEADERS,
+} from './research';
 
 interface SessionData {
   firecrawlApiKey?: string;
   [key: string]: unknown;
 }
 
-/** Whatever `getClient` returns — we only touch its `http.get`. */
-type ClientLike = {
-  http: {
-    get: <T = unknown>(
-      endpoint: string,
-      headers?: Record<string, string>
-    ) => Promise<{ data: T; status: number }>;
-  };
-};
-
-// `getClient` returns a FirecrawlApp whose `http` member is private, so we type
-// the callback loosely and narrow to `ClientLike` at each call site.
-type GetClient = (session?: SessionData) => unknown;
-
 // The other mount, /v2/developer/search, may be withdrawn.
 const BASE = '/v2/search/developer';
-const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
-
 
 interface DeveloperHit {
   /** Stable result id, e.g. `issue:owner/repo#123` or `doc:<hash>`. */

--- a/src/developer.ts
+++ b/src/developer.ts
@@ -87,9 +87,7 @@ export function registerDeveloperTools(
       destructiveHint: false, // Query-only; no writes to external sources or the developer index.
     },
     description: `
-For a developer question — code behaviour, a library or framework, an API contract, an error message, or a known bug — search an index built for coding agents. The index covers GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. Set skills to "only" to limit the search to agent-skill files.
-
-Returns ranked results with an ID, source type, URL, title, and the matched passages in markdown.
+Search indexed GitHub issues, merged pull requests, READMEs, and documentation for a developer question. Use this for code behavior, API contracts, errors, or known bugs rather than general web results.
 `,
     parameters: z.object({
       query: z

--- a/src/index.ts
+++ b/src/index.ts
@@ -1116,6 +1116,80 @@ function recoveryPayload(
   };
 }
 
+function errorText(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 4_000);
+}
+
+function agentLegibleError(
+  code: string,
+  error: unknown,
+  guidance: string,
+  requestId: string = randomUUID(),
+  retryable = false
+): UserError {
+  const originalError = errorText(error);
+  const message = `${originalError}\nRecovery: ${guidance}`;
+  return new UserError(message, {
+    code,
+    message,
+    request_id: requestId,
+    original_error: originalError,
+    retryable,
+    next_actions: [
+      {
+        kind: retryable ? 'retry' : 'check_request',
+        instruction: guidance,
+      },
+    ],
+    docs_url: MCP_CONNECTION_GUIDE_URL,
+  });
+}
+
+function wrapToolError(error: unknown, requestId: string): UserError {
+  if (error instanceof UserError) return error;
+  const message = errorText(error);
+  if (/unauthori[sz]ed|api key|credentials? required/i.test(message)) {
+    return agentLegibleError(
+      'AUTH_REQUIRED',
+      error,
+      'Configure a Firecrawl API key, connect the existing Firecrawl MCP server, or set FIRECRAWL_API_URL for a self-hosted instance, then start a new session and retry.',
+      requestId
+    );
+  }
+  if (/ENOENT|no such file/i.test(message)) {
+    return agentLegibleError(
+      'FILE_NOT_FOUND',
+      error,
+      'Check that filePath exists on the machine running the local MCP server, then retry with the corrected path.',
+      requestId
+    );
+  }
+  if (/timed? out|timeout/i.test(message)) {
+    return agentLegibleError(
+      'UPSTREAM_TIMEOUT',
+      error,
+      'Retry once with a narrower request or a longer supported timeout; if the job ID is known, check its status instead of starting a duplicate job.',
+      requestId,
+      true
+    );
+  }
+  if (/requires|must belong|provide (?:either|exactly)|missing/i.test(message)) {
+    return agentLegibleError(
+      'INVALID_REQUEST',
+      error,
+      'Check the tool arguments against its input schema, correct the invalid or missing value, and retry.',
+      requestId
+    );
+  }
+  return agentLegibleError(
+    'UPSTREAM_REQUEST_FAILED',
+    error,
+    'Verify the request and Firecrawl service availability, then retry once if the operation is safe to repeat.',
+    requestId,
+    true
+  );
+}
+
 function deprecatedExtractPayload() {
   return {
     code: 'DEPRECATED_TOOL',
@@ -1230,25 +1304,71 @@ function guardHostedTool(
         };
       }
       const earlyResult = await beforeValidate?.(args, session);
-      const payload = earlyResult?.structuredContent;
-      const recoveryCode =
-        payload &&
-        typeof payload === 'object' &&
-        'code' in payload &&
-        typeof payload.code === 'string'
-          ? payload.code
-          : undefined;
-      if (logActions && earlyResult?.isError && recoveryCode) {
-        emitActionLog(
-          tool.name,
-          'error',
-          session,
-          new UserError(`Tool validation failed: ${recoveryCode}`, payload),
-          randomUUID(),
-          recoveryCode
-        );
+      if (earlyResult) {
+        const payload = earlyResult.structuredContent;
+        const recoveryCode =
+          payload &&
+          typeof payload === 'object' &&
+          'code' in payload &&
+          typeof payload.code === 'string'
+            ? payload.code
+            : undefined;
+        if (logActions && earlyResult.isError && recoveryCode) {
+          emitActionLog(
+            tool.name,
+            'error',
+            session,
+            new UserError(`Tool validation failed: ${recoveryCode}`, payload),
+            randomUUID(),
+            recoveryCode
+          );
+        }
+        return earlyResult;
       }
-      return earlyResult;
+
+      const schema = tool.parameters as typeof tool.parameters & {
+        safeParseAsync?: (value: unknown) => Promise<{
+          success: boolean;
+          error?: { issues?: Array<{ message?: string; path?: PropertyKey[] }> };
+        }>;
+      };
+      if (schema?.safeParseAsync) {
+        const validation = await schema.safeParseAsync(args);
+        if (!validation.success) {
+          const issueText = (validation.error?.issues ?? [])
+            .slice(0, 10)
+            .map((issue) => {
+              const location = issue.path?.length
+                ? `${issue.path.map(String).join('.')}: `
+                : '';
+              return `${location}${issue.message ?? 'Invalid value'}`;
+            })
+            .join('; ');
+          const requestId = randomUUID();
+          const error = agentLegibleError(
+            'INVALID_REQUEST',
+            issueText || 'Tool arguments failed validation.',
+            'Check the tool arguments against its input schema, correct the listed values, and retry.',
+            requestId
+          );
+          if (logActions) {
+            emitActionLog(
+              tool.name,
+              'error',
+              session,
+              error,
+              requestId,
+              'INVALID_REQUEST'
+            );
+          }
+          return {
+            content: [{ type: 'text' as const, text: error.message }],
+            isError: true,
+            structuredContent: error.extras,
+          };
+        }
+      }
+      return undefined;
     },
     execute: async (args, context) => {
       const requestId = randomUUID();
@@ -1274,16 +1394,30 @@ function guardHostedTool(
         if (logActions) emitActionLog(tool.name, 'error', invocationSession, new UserError(String(payload.message), payload), requestId, code);
         throw new UserError(String(payload.message), payload);
       }
-      if (!logActions) return execute(args, invocationContext);
-
-      emitActionLog(tool.name, 'started', invocationSession, undefined, requestId);
+      if (logActions) {
+        emitActionLog(tool.name, 'started', invocationSession, undefined, requestId);
+      }
       try {
         const result = await execute(args, invocationContext);
-        emitActionLog(tool.name, 'success', invocationSession, undefined, requestId);
+        if (logActions) {
+          emitActionLog(tool.name, 'success', invocationSession, undefined, requestId);
+        }
         return result;
       } catch (error) {
-        emitActionLog(tool.name, 'error', invocationSession, error, requestId);
-        throw error;
+        const wrapped = wrapToolError(error, requestId);
+        if (logActions) {
+          emitActionLog(
+            tool.name,
+            'error',
+            invocationSession,
+            wrapped,
+            requestId,
+            typeof wrapped.extras?.code === 'string'
+              ? wrapped.extras.code
+              : undefined
+          );
+        }
+        throw wrapped;
       }
     },
   };
@@ -1499,6 +1633,81 @@ function withTruncationMetadata(
   return value && typeof value === 'object' && !Array.isArray(value)
     ? { ...(value as Record<string, unknown>), _firecrawl: metadata }
     : { result: value, _firecrawl: metadata };
+}
+
+type ResultNoticeKind = 'scrape' | 'search' | 'map' | 'crawl' | 'agent';
+
+function resultRecord(data: unknown): Record<string, any> | undefined {
+  return data && typeof data === 'object' && !Array.isArray(data)
+    ? (data as Record<string, any>)
+    : undefined;
+}
+
+function withResultNotice(
+  data: unknown,
+  kind: ResultNoticeKind
+): unknown {
+  const root = resultRecord(data);
+  if (!root) return data;
+  const body = resultRecord(root.data) ?? root;
+  const statusCode = Number(body.metadata?.statusCode ?? root.statusCode);
+  const blocked =
+    kind === 'scrape' &&
+    ([401, 403, 429].includes(statusCode) ||
+      /blocked|captcha|access denied/i.test(
+        String(body.warning ?? body.error ?? root.warning ?? root.error ?? '')
+      ));
+
+  let empty = false;
+  if (kind === 'scrape') {
+    const contentFields = ['markdown', 'html', 'rawHtml', 'json', 'summary'];
+    empty = contentFields.some((field) => field in body) &&
+      contentFields.every((field) => body[field] == null || body[field] === '');
+  } else if (kind === 'search') {
+    const groups = Object.values(resultRecord(root.data) ?? {}).filter(Array.isArray);
+    empty = groups.length > 0 && groups.every((group) => group.length === 0);
+  } else if (kind === 'map') {
+    empty = Array.isArray(body.links) && body.links.length === 0;
+  } else if (kind === 'crawl') {
+    empty = Array.isArray(root.data) && root.data.length === 0;
+  } else if (kind === 'agent') {
+    empty = Object.keys(body).length === 0;
+  }
+  if (!blocked && !empty) return data;
+
+  const notice = blocked
+    ? {
+        code: 'LIKELY_BLOCKED',
+        warning: true,
+        message:
+          'The response is empty or incomplete and carries a likely blocking signal from the target site.',
+        next_actions: [
+          {
+            kind: 'adjust_request',
+            instruction:
+              'Verify the URL and retry with a supported proxy or a narrower scrape request; do not treat this response as page content.',
+          },
+        ],
+      }
+    : {
+        code: 'EMPTY_RESULT',
+        warning: true,
+        message: 'Firecrawl returned an empty result for this request.',
+        next_actions: [
+          {
+            kind: 'adjust_request',
+            instruction:
+              'Verify the URL, query, filters, or job status and retry with corrected or broader inputs if appropriate.',
+          },
+        ],
+      };
+  return {
+    ...root,
+    _firecrawl: {
+      ...(resultRecord(root._firecrawl) ?? {}),
+      ...notice,
+    },
+  };
 }
 
 function formatToolResponse(
@@ -2021,18 +2230,21 @@ async function executeHostedParse(
   const hasUploadRef =
     typeof args.uploadRef === 'string' && args.uploadRef.length > 0;
   if (hasFilePath === hasUploadRef) {
-    throw new Error(
-      'Hosted firecrawl_parse requires exactly one of filePath or uploadRef.'
+    throw agentLegibleError(
+      'PARSE_INPUT_INVALID',
+      'Hosted firecrawl_parse requires exactly one of filePath or uploadRef.',
+      'Provide filePath for phase one or uploadRef for phase two, but not both, then retry.',
+      session?.requestId
     );
   }
 
   if (!hasCredential(session) && !isKeylessMode(session)) {
-    return asText({
-      success: false,
-      mode: 'hosted-upload-ref-auth-required',
-      message:
-        'Hosted firecrawl_parse requires an authenticated Firecrawl session or keyless eligibility before a local file upload URL can be minted. Connect a Firecrawl account, provide an API key, or use keyless hosted MCP while eligible, then call firecrawl_parse again.',
-    });
+    throw agentLegibleError(
+      'AUTH_REQUIRED',
+      'Hosted firecrawl_parse requires an authenticated Firecrawl session or keyless eligibility.',
+      'Connect the existing Firecrawl MCP server, configure an API key, or use eligible hosted keyless mode, then start a new session and retry.',
+      session?.requestId
+    );
   }
 
   if (isHostedKeylessSession(session) && args.zeroDataRetention === true) {
@@ -2175,7 +2387,7 @@ Returns the selected content formats and page metadata. \`response_format\` defa
         session
       );
       return formatToolResponse(
-        json?.data ?? json,
+        withResultNotice(json?.data ?? json, 'scrape'),
         response_format,
         'Request fewer formats or narrow the extraction to retrieve omitted page content.'
       );
@@ -2186,7 +2398,7 @@ Returns the selected content formats and page metadata. \`response_format\` defa
       origin: ORIGIN,
     } as any);
     return formatToolResponse(
-      res,
+      withResultNotice(res, 'scrape'),
       response_format,
       'Request fewer formats or narrow the extraction to retrieve omitted page content.'
     );
@@ -2227,7 +2439,7 @@ Returns matching URLs rather than page bodies. Retrieve one page with \`firecraw
       origin: ORIGIN,
     } as any);
     return formatToolResponse(
-      res,
+      withResultNotice(res, 'map'),
       'detailed',
       'Retry firecrawl_map with a lower limit or narrower search term to retrieve omitted URLs.'
     );
@@ -2297,7 +2509,7 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
       const keylessResponse = { ...(json ?? {}) };
       delete keylessResponse.id;
       return formatToolResponse(
-        keylessResponse,
+        withResultNotice(keylessResponse, 'search'),
         response_format,
         'Use a lower limit, narrower query, or fewer scrapeOptions formats to retrieve omitted results.'
       );
@@ -2309,7 +2521,7 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
     const client = getClient(session);
     const httpRes = await (client as any).http.post('/v2/search', searchBody);
     return formatToolResponse(
-      httpRes?.data ?? {},
+      withResultNotice(httpRes?.data ?? {}, 'search'),
       response_format,
       'Use a lower limit, narrower query, or fewer scrapeOptions formats to retrieve omitted results.'
     );
@@ -2681,7 +2893,12 @@ Eligibility is limited to successful searches within the feedback age window. Th
       if (credential) {
         headers['Authorization'] = `Bearer ${credential}`;
       } else if (process.env.CLOUD_SERVICE === 'true') {
-        throw new Error('Unauthorized: missing API key for search feedback.');
+        throw agentLegibleError(
+          'AUTH_REQUIRED',
+          'Search feedback requires an authenticated Firecrawl account.',
+          'Connect the existing Firecrawl MCP server or configure an API key, then start a new session and retry.',
+          session?.requestId
+        );
       }
 
       log.info('Submitting search feedback', { searchId, rating });
@@ -2707,13 +2924,15 @@ Eligibility is limited to successful searches within the feedback age window. Th
           status: response.status,
           feedbackErrorCode: parsed?.feedbackErrorCode,
         });
-        return asText({
-          success: false,
-          status: response.status,
-          feedbackErrorCode: parsed?.feedbackErrorCode,
-          error: parsed?.error ?? `HTTP ${response.status}`,
-          retryable: response.status >= 500,
-        });
+        throw agentLegibleError(
+          'FEEDBACK_REJECTED',
+          parsed?.error ?? `HTTP ${response.status}`,
+          response.status >= 500
+            ? 'Retry once later with the same substantive feedback.'
+            : 'Check the search ID, feedback fields, and submission window before retrying.',
+          session?.requestId,
+          response.status >= 500
+        );
       }
 
       return asText(parsed);
@@ -2793,7 +3012,12 @@ Returns submission status, feedback ID, and accounting fields.
       if (credential) {
         headers['Authorization'] = `Bearer ${credential}`;
       } else if (process.env.CLOUD_SERVICE === 'true') {
-        throw new Error('Unauthorized: missing API key for feedback.');
+        throw agentLegibleError(
+          'AUTH_REQUIRED',
+          'Endpoint feedback requires an authenticated Firecrawl account.',
+          'Connect the existing Firecrawl MCP server or configure an API key, then start a new session and retry.',
+          session?.requestId
+        );
       }
 
       const body = removeEmptyTopLevel({
@@ -2832,13 +3056,15 @@ Returns submission status, feedback ID, and accounting fields.
           status: response.status,
           feedbackErrorCode: parsed?.feedbackErrorCode,
         });
-        return asText({
-          success: false,
-          status: response.status,
-          feedbackErrorCode: parsed?.feedbackErrorCode,
-          error: parsed?.error ?? `HTTP ${response.status}`,
-          retryable: response.status >= 500,
-        });
+        throw agentLegibleError(
+          'FEEDBACK_REJECTED',
+          parsed?.error ?? `HTTP ${response.status}`,
+          response.status >= 500
+            ? 'Retry once later with the same substantive feedback.'
+            : 'Check the job ID, feedback fields, and submission window before retrying.',
+          session?.requestId,
+          response.status >= 500
+        );
       }
 
       return asText(parsed);
@@ -2927,10 +3153,12 @@ Crawl results can be large; use conservative limits when full-site coverage is u
     });
     const crawlId = started?.data?.id;
     if (!crawlId) {
-      return formatToolResponse(
-        started?.data ?? {},
-        response_format,
-        'Use a narrower crawl request to retrieve omitted response fields.'
+      throw agentLegibleError(
+        'CRAWL_START_FAILED',
+        started?.data?.error ?? 'Firecrawl did not return a crawl job ID.',
+        'Check the crawl URL and options, then retry once; do not report a crawl as started without a job ID.',
+        session?.requestId,
+        true
       );
     }
     const res = await waitForCrawlCompletionWithOrigin(
@@ -2940,7 +3168,7 @@ Crawl results can be large; use conservative limits when full-site coverage is u
       timeout
     );
     return formatToolResponse(
-      res,
+      withResultNotice(res, 'crawl'),
       response_format,
       res.next
         ? `Call firecrawl_check_crawl_status with id: "${crawlId}" and next: "${String(res.next)}" to retrieve later documents; narrow scrapeOptions to retrieve omitted document fields.`
@@ -2981,7 +3209,7 @@ Retrieve the current status, progress, and available results for an existing cra
     };
     const res = await getCrawlStatusWithOrigin(client, id, next);
     return formatToolResponse(
-      res,
+      withResultNotice(res, 'crawl'),
       response_format,
       res.next
         ? `Call firecrawl_check_crawl_status with id: "${id}" and next: "${String(res.next)}" to retrieve later documents; narrow the crawl request to retrieve omitted document fields.`
@@ -3091,7 +3319,7 @@ Returns job status, progress information, and result data when completed. \`resp
       ORIGIN_HEADERS
     );
     return formatToolResponse(
-      res?.data ?? {},
+      withResultNotice(res?.data ?? {}, 'agent'),
       response_format,
       'Use a narrower agent prompt or schema to retrieve omitted result content.'
     );
@@ -3170,25 +3398,20 @@ This acts on the live site, so actions such as form submission can create persis
       } as any);
       scrapeId = (scraped as any)?.metadata?.scrapeId;
       if (!scrapeId) {
-        return formatToolResponse(
-          {
-            error:
-              'Could not open an interact session: the scrape did not return a scrapeId. Try firecrawl_scrape first, then pass its scrapeId.',
-            url,
-          },
-          response_format,
-          'Use a shorter URL to retrieve the complete error response.'
+        throw agentLegibleError(
+          'INTERACT_SESSION_UNAVAILABLE',
+          'The scrape did not return a scrapeId.',
+          'Verify the URL, call firecrawl_scrape, and retry firecrawl_interact with the returned scrapeId.',
+          session?.requestId
         );
       }
     }
     if (!scrapeId) {
-      return formatToolResponse(
-        {
-          error: 'Could not open an interact session: missing scrapeId.',
-          url,
-        },
-        response_format,
-        'Use a shorter URL to retrieve the complete error response.'
+      throw agentLegibleError(
+        'INTERACT_SESSION_UNAVAILABLE',
+        'Could not open an interact session because scrapeId is missing.',
+        'Call firecrawl_scrape and retry firecrawl_interact with its scrapeId.',
+        session?.requestId
       );
     }
     const activeScrapeId = scrapeId;
@@ -3275,8 +3498,11 @@ Set \`redactPII\` to request redaction of personally identifiable information in
 
     const apiUrl = process.env.FIRECRAWL_API_URL;
     if (!apiUrl) {
-      throw new Error(
-        'firecrawl_parse requires FIRECRAWL_API_URL to be set to a self-hosted Firecrawl API instance.'
+      throw agentLegibleError(
+        'PARSE_CONFIG_REQUIRED',
+        'firecrawl_parse requires FIRECRAWL_API_URL to be set to a self-hosted Firecrawl API instance.',
+        'Set FIRECRAWL_API_URL on the local MCP server, start a new session, and retry.',
+        session?.requestId
       );
     }
 
@@ -3331,8 +3557,12 @@ Set \`redactPII\` to request redaction of personally identifiable information in
 
     const responseText = await response.text();
     if (!response.ok) {
-      throw new Error(
-        `Parse request failed with status ${response.status}: ${responseText}`
+      throw agentLegibleError(
+        'PARSE_REQUEST_FAILED',
+        `Parse request failed with status ${response.status}: ${responseText}`,
+        'Verify the file type and parse options, then retry once if the request is safe to repeat.',
+        session?.requestId,
+        response.status >= 500
       );
     }
 
@@ -3444,7 +3674,7 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`. 
       const client = getClientFn(session);
       const httpRes = await (client as any).http.post('/v2/search', searchBody);
       return formatToolResponse(
-        httpRes?.data ?? {},
+        withResultNotice(httpRes?.data ?? {}, 'search'),
         response_format,
         'Use a lower limit or narrower query to retrieve omitted results.'
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ function createOAuthChallengeResponse(
 }
 
 function createInvalidCredentialResponse(_error: InvalidFirecrawlCredentialError): Response {
-  const recovery = invalidApiKeyRecoveryPayload();
+  const recovery = INVALID_API_KEY_RECOVERY_PAYLOAD;
   return new Response(
     JSON.stringify({
       error: 'invalid_api_key',
@@ -364,10 +364,9 @@ class InvalidOAuthCredentialError extends Error {
 const MCP_GLOBAL_SCOPE = 'firecrawl:global';
 
 function values(value: string | string[] | undefined): string[] {
-  if (typeof value === 'string') return value.split(/\s+/).filter(Boolean);
-  return Array.isArray(value)
-    ? value.flatMap((item) => item.split(/\s+/).filter(Boolean))
-    : [];
+  return (Array.isArray(value) ? value : value ? [value] : [])
+    .flatMap((item) => item.split(/\s+/))
+    .filter(Boolean);
 }
 
 function audienceMatchesResource(
@@ -718,7 +717,7 @@ function makeAuthenticate(profile: ServerProfile) {
           throw createInvalidCredentialResponse(error);
         }
         if (error instanceof InvalidOAuthCredentialError) {
-          const recovery = invalidOAuthRecoveryPayload();
+          const recovery = INVALID_OAUTH_RECOVERY_PAYLOAD;
           const oauthChallenge = createOAuthChallengeResponse(
             new Error(recovery.message),
             profile,
@@ -877,31 +876,22 @@ class ConsoleLogger implements Logger {
     process.env.SSE_LOCAL === 'true' ||
     process.env.HTTP_STREAMABLE_SERVER === 'true';
 
-  debug(...args: unknown[]): void {
-    if (this.shouldLog) {
-      console.debug('[DEBUG]', new Date().toISOString(), ...args);
-    }
+  private gatedLogger(
+    method: 'debug' | 'error' | 'log' | 'warn',
+    level: string
+  ): (...args: unknown[]) => void {
+    return (...args) => {
+      if (this.shouldLog) {
+        console[method](`[${level}]`, new Date().toISOString(), ...args);
+      }
+    };
   }
-  error(...args: unknown[]): void {
-    if (this.shouldLog) {
-      console.error('[ERROR]', new Date().toISOString(), ...args);
-    }
-  }
-  info(...args: unknown[]): void {
-    if (this.shouldLog) {
-      console.log('[INFO]', new Date().toISOString(), ...args);
-    }
-  }
-  log(...args: unknown[]): void {
-    if (this.shouldLog) {
-      console.log('[LOG]', new Date().toISOString(), ...args);
-    }
-  }
-  warn(...args: unknown[]): void {
-    if (this.shouldLog) {
-      console.warn('[WARN]', new Date().toISOString(), ...args);
-    }
-  }
+
+  debug = this.gatedLogger('debug', 'DEBUG');
+  error = this.gatedLogger('error', 'ERROR');
+  info = this.gatedLogger('log', 'INFO');
+  log = this.gatedLogger('log', 'LOG');
+  warn = this.gatedLogger('warn', 'WARN');
 }
 
 const openAiAppsChallengeToken = normalizeHeader(
@@ -1076,34 +1066,39 @@ const INVALID_API_KEY_MESSAGE =
 const INVALID_OAUTH_MESSAGE =
   'This Firecrawl account connection is no longer valid.\nFix: Reconnect the existing Firecrawl server in the client, or set that existing server URL to https://mcp.firecrawl.dev/v2/mcp-oauth, then start a new session.';
 
-function connectionRecoveryPayload(params: {
-  code: string;
-  authMode: string;
+const INVALID_API_KEY_RECOVERY_PAYLOAD: Record<string, unknown> & {
   message: string;
-}): Record<string, unknown> & { message: string } {
-  return {
-    code: params.code,
-    auth_mode: params.authMode,
-    message: params.message,
-    docs_url: MCP_CONNECTION_GUIDE_URL,
-  };
-}
+} = {
+  code: 'CREDENTIAL_INVALID',
+  auth_mode: 'api_key',
+  message: INVALID_API_KEY_MESSAGE,
+  docs_url: MCP_CONNECTION_GUIDE_URL,
+};
 
-function invalidApiKeyRecoveryPayload(): Record<string, unknown> & { message: string } {
-  return connectionRecoveryPayload({
-    code: 'CREDENTIAL_INVALID',
-    authMode: 'api_key',
-    message: INVALID_API_KEY_MESSAGE,
-  });
-}
+const INVALID_OAUTH_RECOVERY_PAYLOAD: Record<string, unknown> & {
+  message: string;
+} = {
+  code: 'OAUTH_CONNECTION_INVALID',
+  auth_mode: 'oauth',
+  message: INVALID_OAUTH_MESSAGE,
+  docs_url: MCP_CONNECTION_GUIDE_URL,
+};
 
-function invalidOAuthRecoveryPayload(): Record<string, unknown> & { message: string } {
-  return connectionRecoveryPayload({
-    code: 'OAUTH_CONNECTION_INVALID',
-    authMode: 'oauth',
-    message: INVALID_OAUTH_MESSAGE,
-  });
-}
+const RECOVERY_MESSAGES: Record<string, string> = {
+  CREDENTIAL_INVALID: INVALID_API_KEY_MESSAGE,
+  KEYLESS_QUOTA_EXHAUSTED: KEYLESS_QUOTA_MESSAGE,
+  KEYLESS_LIMIT_REACHED: KEYLESS_QUOTA_MESSAGE,
+  KEYLESS_TOOL_NOT_AVAILABLE: KEYLESS_TOOL_MESSAGE,
+  KEYLESS_ACCESS_NOT_AVAILABLE: KEYLESS_ACCESS_MESSAGE,
+  KEYLESS_ELIGIBILITY_UNAVAILABLE:
+    'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.',
+};
+const KEYLESS_CONVERSION_CODES = new Set([
+  'KEYLESS_QUOTA_EXHAUSTED',
+  'KEYLESS_LIMIT_REACHED',
+  'KEYLESS_TOOL_NOT_AVAILABLE',
+  'KEYLESS_ACCESS_NOT_AVAILABLE',
+]);
 
 function recoveryPayload(
   code: string,
@@ -1111,30 +1106,16 @@ function recoveryPayload(
   options: { retryAfterSeconds?: number } = {}
 ): Record<string, unknown> {
   const retryAfterSeconds = options.retryAfterSeconds;
-  const isQuotaExhausted =
-    code === 'KEYLESS_QUOTA_EXHAUSTED' || code === 'KEYLESS_LIMIT_REACHED';
-  const isToolUnavailable = code === 'KEYLESS_TOOL_NOT_AVAILABLE';
-  const isKeylessAccessUnavailable = code === 'KEYLESS_ACCESS_NOT_AVAILABLE';
   const isKeylessEligibilityUnavailable =
     code === 'KEYLESS_ELIGIBILITY_UNAVAILABLE';
-  const isKeylessConversion =
-    isQuotaExhausted || isToolUnavailable || isKeylessAccessUnavailable;
+  const isKeylessConversion = KEYLESS_CONVERSION_CODES.has(code);
   return {
     code,
     request_id: requestId,
     auth_mode: code === 'CREDENTIAL_INVALID' ? 'credential_error' : 'keyless',
     message:
-      code === 'CREDENTIAL_INVALID'
-        ? INVALID_API_KEY_MESSAGE
-        : isQuotaExhausted
-          ? KEYLESS_QUOTA_MESSAGE
-          : isToolUnavailable
-            ? KEYLESS_TOOL_MESSAGE
-            : isKeylessAccessUnavailable
-              ? KEYLESS_ACCESS_MESSAGE
-              : isKeylessEligibilityUnavailable
-                ? 'The anonymous keyless eligibility check is temporarily unavailable. Retry shortly.'
-                : 'This tool requires a Firecrawl account or API key.',
+      RECOVERY_MESSAGES[code] ??
+      'This tool requires a Firecrawl account or API key.',
     // CREDENTIAL_INVALID sessions gate every tool call (including keyless
     // tools) on the credentialError check before the keyless branch ever
     // runs, so none of KEYLESS_TOOL_NAMES are actually callable here. Listing
@@ -1157,8 +1138,22 @@ function errorText(error: unknown): string {
   return (error instanceof Error ? error.message : String(error)).slice(0, 4_000);
 }
 
+type ToolErrorCode =
+  | 'AUTH_REQUIRED'
+  | 'FILE_NOT_FOUND'
+  | 'UNSUPPORTED_SITE'
+  | 'UPSTREAM_TIMEOUT'
+  | 'INVALID_REQUEST'
+  | 'UPSTREAM_REQUEST_FAILED'
+  | 'CRAWL_START_FAILED'
+  | 'PARSE_INPUT_INVALID'
+  | 'PARSE_CONFIG_REQUIRED'
+  | 'PARSE_REQUEST_FAILED'
+  | 'INTERACT_SESSION_UNAVAILABLE'
+  | 'FEEDBACK_REJECTED';
+
 function agentLegibleError(
-  code: string,
+  code: ToolErrorCode,
   error: unknown,
   guidance: string,
   requestId: string = randomUUID(),
@@ -1180,6 +1175,13 @@ function agentLegibleError(
     ],
     docs_url: MCP_CONNECTION_GUIDE_URL,
   });
+}
+
+class InvalidCrawlContinuationError extends Error {
+  constructor() {
+    super('Crawl continuation must belong to this crawl job.');
+    this.name = 'InvalidCrawlContinuationError';
+  }
 }
 
 function wrapToolError(error: unknown, requestId: string): UserError {
@@ -1218,7 +1220,7 @@ function wrapToolError(error: unknown, requestId: string): UserError {
       true
     );
   }
-  if (/^Crawl continuation must belong to this crawl job\.$/.test(message)) {
+  if (error instanceof InvalidCrawlContinuationError) {
     return agentLegibleError(
       'INVALID_REQUEST',
       error,
@@ -1703,9 +1705,9 @@ function withTruncationMetadata(
 
 type ResultNoticeKind = 'scrape' | 'search' | 'map' | 'crawl' | 'agent';
 
-function resultRecord(data: unknown): Record<string, any> | undefined {
+function resultRecord(data: unknown): Record<string, unknown> | undefined {
   return data && typeof data === 'object' && !Array.isArray(data)
-    ? (data as Record<string, any>)
+    ? (data as Record<string, unknown>)
     : undefined;
 }
 
@@ -1716,33 +1718,51 @@ function withResultNotice(
   const root = resultRecord(data);
   if (!root) return data;
   const body = resultRecord(root.data) ?? root;
-  const statusCode = Number(body.metadata?.statusCode ?? root.statusCode);
+  const metadata = resultRecord(body.metadata);
+  const statusCode = Number(metadata?.statusCode ?? root.statusCode);
 
   let empty = false;
   let blocked = false;
-  if (kind === 'scrape') {
-    const contentFields = ['markdown', 'html', 'rawHtml', 'json', 'summary'];
-    const contentLength = contentFields.reduce(
-      (length, field) => length + JSON.stringify(body[field] ?? '').length,
-      0
-    );
-    empty = contentFields.some((field) => field in body) &&
-      contentFields.every((field) => body[field] == null || body[field] === '');
-    const blockingSignal =
-      [401, 403, 429].includes(statusCode) ||
-      /blocked|captcha|access denied/i.test(
-        String(body.warning ?? body.error ?? root.warning ?? root.error ?? '')
+  switch (kind) {
+    case 'scrape': {
+      const contentFields = ['markdown', 'html', 'rawHtml', 'json', 'summary'];
+      const contentLength = contentFields.reduce(
+        (length, field) => length + JSON.stringify(body[field] ?? '').length,
+        0
       );
-    blocked = blockingSignal && (empty || contentLength <= 200);
-  } else if (kind === 'search') {
-    const groups = Object.values(resultRecord(root.data) ?? {}).filter(Array.isArray);
-    empty = groups.length > 0 && groups.every((group) => group.length === 0);
-  } else if (kind === 'map') {
-    empty = Array.isArray(body.links) && body.links.length === 0;
-  } else if (kind === 'crawl') {
-    empty = Array.isArray(root.data) && root.data.length === 0;
-  } else if (kind === 'agent') {
-    empty = Object.keys(body).length === 0;
+      empty =
+        contentFields.some((field) => field in body) &&
+        contentFields.every(
+          (field) => body[field] == null || body[field] === ''
+        );
+      const blockingSignal =
+        [401, 403, 429].includes(statusCode) ||
+        /blocked|captcha|access denied/i.test(
+          String(body.warning ?? body.error ?? root.warning ?? root.error ?? '')
+        );
+      blocked = blockingSignal && (empty || contentLength <= 200);
+      break;
+    }
+    case 'search': {
+      const groups = Object.values(resultRecord(root.data) ?? {}).filter(
+        Array.isArray
+      );
+      empty = groups.length > 0 && groups.every((group) => group.length === 0);
+      break;
+    }
+    case 'map':
+      empty = Array.isArray(body.links) && body.links.length === 0;
+      break;
+    case 'crawl':
+      empty = Array.isArray(root.data) && root.data.length === 0;
+      break;
+    case 'agent':
+      empty = Object.keys(body).length === 0;
+      break;
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
   }
   if (!blocked && !empty) return data;
 
@@ -2268,12 +2288,12 @@ function inferContentType(filename: string): string {
   return EXTENSION_CONTENT_TYPES[ext] ?? 'application/octet-stream';
 }
 
-type ParseToolArgs = {
-  filePath?: string;
-  uploadRef?: string;
-  contentType?: string;
-  declaredSizeBytes?: number;
-} & Record<string, unknown>;
+type HostedParseToolArgs = z.infer<typeof hostedParseParamsSchema>;
+type ParseToolArgs = Omit<HostedParseToolArgs, 'filePath' | 'uploadRef'> &
+  (
+    | { filePath: string; uploadRef?: never }
+    | { filePath?: never; uploadRef: string }
+  );
 
 function extractParseOptions(args: ParseToolArgs): Record<string, unknown> {
   const options = { ...args };
@@ -2291,18 +2311,6 @@ function buildParseOptionsPayload(
   const transformed = transformScrapeParams(options);
   const cleaned = removeEmptyTopLevel(transformed) as Record<string, unknown>;
   return { origin: ORIGIN, ...cleaned };
-}
-
-function buildContinuationArguments(
-  uploadRef: string,
-  options: Record<string, unknown>,
-  responseFormat: ResponseFormat
-): Record<string, unknown> {
-  return {
-    uploadRef,
-    ...(removeEmptyTopLevel(options) as Record<string, unknown>),
-    response_format: responseFormat,
-  };
 }
 
 function shellQuote(value: string): string {
@@ -2414,19 +2422,6 @@ async function executeHostedParse(
   session: SessionData | undefined,
   log: ToolLogger
 ): Promise<string> {
-  const hasFilePath =
-    typeof args.filePath === 'string' && args.filePath.length > 0;
-  const hasUploadRef =
-    typeof args.uploadRef === 'string' && args.uploadRef.length > 0;
-  if (hasFilePath === hasUploadRef) {
-    throw agentLegibleError(
-      'PARSE_INPUT_INVALID',
-      'Hosted firecrawl_parse requires exactly one of filePath or uploadRef.',
-      'Provide filePath for phase one or uploadRef for phase two, but not both, then retry.',
-      session?.requestId
-    );
-  }
-
   if (!hasCredential(session) && !isKeylessMode(session)) {
     throw agentLegibleError(
       'AUTH_REQUIRED',
@@ -2446,10 +2441,10 @@ async function executeHostedParse(
     throw new UserError(String(payload.message), payload);
   }
 
-  const responseFormat = (args.response_format ?? 'detailed') as ResponseFormat;
+  const responseFormat = args.response_format ?? 'detailed';
   const options = extractParseOptions(args);
 
-  if (hasFilePath && args.filePath) {
+  if (args.filePath) {
     const filename = path.basename(args.filePath);
     const contentType =
       typeof args.contentType === 'string' && args.contentType.length > 0
@@ -2499,11 +2494,11 @@ async function executeHostedParse(
       },
       nextToolCall: {
         name: 'firecrawl_parse',
-        arguments: buildContinuationArguments(
-          upload.uploadRef,
-          options,
-          responseFormat
-        ),
+        arguments: {
+          uploadRef: upload.uploadRef,
+          ...(removeEmptyTopLevel(options) as Record<string, unknown>),
+          response_format: responseFormat,
+        },
       },
         notes: [
           'Run the curl command on the machine that can read filePath.',
@@ -2517,7 +2512,7 @@ async function executeHostedParse(
   }
 
   const parsePayload = {
-    uploadRef: args.uploadRef as string,
+    uploadRef: args.uploadRef,
     ...buildParseOptionsPayload(options),
   };
   log.info('Parsing hosted upload reference');
@@ -2546,13 +2541,10 @@ Retrieve content or structured fields from one supplied URL. Use this when the r
 `,
   parameters: scrapeParamsSchema,
   execute: async (args: unknown, { session, log }): Promise<string> => {
-    const { url, response_format = 'detailed', ...options } = args as {
-      url: string;
-      response_format?: ResponseFormat;
-    } & Record<string, unknown>;
-    const transformed = transformScrapeParams(
-      options as Record<string, unknown>
-    );
+    const { url, response_format = 'detailed', ...options } = args as z.infer<
+      typeof scrapeParamsSchema
+    >;
+    const transformed = transformScrapeParams(options);
     const cleaned = removeEmptyTopLevel(transformed);
     if (cleaned.lockdown) {
       log.info('Scraping URL (lockdown)');
@@ -2852,8 +2844,28 @@ async function keylessPost(
   return json;
 }
 
-function crawlPageData(body: any): unknown[] {
-  return Array.isArray(body.data) ? body.data : body.data?.pages || [];
+type CrawlClientLike = {
+  http: {
+    get: <T = unknown>(
+      endpoint: string,
+      headers?: Record<string, string>
+    ) => Promise<{ data: T; status: number }>;
+  };
+};
+
+function crawlPageData(body: unknown): unknown[] {
+  const data = resultRecord(body)?.data;
+  if (Array.isArray(data)) return data;
+  const pages = resultRecord(data)?.pages;
+  return Array.isArray(pages) ? pages : [];
+}
+
+function crawlNext(body: Record<string, unknown>): string | null {
+  if ('next' in body && typeof body.next === 'string') return body.next;
+  const data = Array.isArray(body.data) ? undefined : resultRecord(body.data);
+  return data && 'next' in data && typeof data.next === 'string'
+    ? data.next
+    : null;
 }
 
 function crawlDataBytes(docs: unknown[]): number {
@@ -2866,7 +2878,7 @@ function validatedCrawlContinuation(jobId: string, continuation: string): string
   const apiBasePath = apiBase.pathname.replace(/\/$/, '');
   const expectedPath = `${apiBasePath}/v2/crawl/${encodeURIComponent(jobId)}`;
   if (url.origin !== apiBase.origin || url.pathname !== expectedPath) {
-    throw new Error('Crawl continuation must belong to this crawl job.');
+    throw new InvalidCrawlContinuationError();
   }
   return `${url.pathname.slice(apiBasePath.length)}${url.search}`;
 }
@@ -2884,46 +2896,54 @@ function takeCrawlDocumentWindow(documents: unknown[], offset: number): unknown[
   return window;
 }
 
-function crawlOffsetNotice(
-  jobId: string,
-  offset: number,
-  shown: number,
-  total: number | undefined,
-  hasMore: boolean,
-  next?: string
-): Record<string, unknown> {
-  const first = shown > 0 ? offset + 1 : offset;
-  const last = offset + shown;
-  const range = shown > 0 ? `${first}-${last}` : 'empty';
-  const totalText = total == null ? '' : ` of ${total}`;
-  const nextOffset = offset + shown;
-  const nextArg = next == null ? '' : `, next: "${next}"`;
-  return {
-    truncated: hasMore,
-    shown_range: { start: first, end: last, ...(total == null ? {} : { total }) },
-    ...(hasMore ? { next_offset: nextOffset, ...(next == null ? {} : { next }) } : {}),
-    message: hasMore
-      ? `Shown documents ${range}${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}"${nextArg} and offset: ${nextOffset} to retrieve later documents.`
-      : `Shown documents ${range}${totalText}. All available documents have been returned.`,
-  };
-}
+type CrawlNoticeContinuation =
+  | { offset: number; hasMore: boolean; next?: string }
+  | { next: string };
 
-function crawlCursorNotice(
+function crawlWindowNotice(
   jobId: string,
   shown: number,
   total: number | undefined,
-  next: string
+  continuation: CrawlNoticeContinuation
 ): Record<string, unknown> {
+  if ('offset' in continuation) {
+    const { offset, hasMore, next } = continuation;
+    const first = shown > 0 ? offset + 1 : offset;
+    const last = offset + shown;
+    const range = shown > 0 ? `${first}-${last}` : 'empty';
+    const totalText = total == null ? '' : ` of ${total}`;
+    const nextOffset = offset + shown;
+    const nextArg = next == null ? '' : `, next: "${next}"`;
+    return {
+      truncated: hasMore,
+      shown_range: {
+        start: first,
+        end: last,
+        ...(total == null ? {} : { total }),
+      },
+      ...(hasMore
+        ? { next_offset: nextOffset, ...(next == null ? {} : { next }) }
+        : {}),
+      message: hasMore
+        ? `Shown documents ${range}${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}"${nextArg} and offset: ${nextOffset} to retrieve later documents.`
+        : `Shown documents ${range}${totalText}. All available documents have been returned.`,
+    };
+  }
+
   const totalText = total == null ? '' : ` of ${total} total`;
   return {
     truncated: true,
-    shown_range: { start: shown > 0 ? 1 : 0, end: shown, ...(total == null ? {} : { total }) },
-    message: `Shown documents ${shown > 0 ? `1-${shown}` : 'empty'} in this cursor window${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}" and next: "${next}" to retrieve later documents.`,
+    shown_range: {
+      start: shown > 0 ? 1 : 0,
+      end: shown,
+      ...(total == null ? {} : { total }),
+    },
+    message: `Shown documents ${shown > 0 ? `1-${shown}` : 'empty'} in this cursor window${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}" and next: "${continuation.next}" to retrieve later documents.`,
   };
 }
 
 async function getCrawlStatusWithOrigin(
-  client: FirecrawlApp,
+  client: unknown,
   jobId: string,
   continuation?: string,
   offset = 0
@@ -2931,13 +2951,11 @@ async function getCrawlStatusWithOrigin(
   const requestPath = continuation
     ? validatedCrawlContinuation(jobId, continuation)
     : `/v2/crawl/${encodeURIComponent(jobId)}`;
-  const res = await (client as any).http.get(requestPath, ORIGIN_HEADERS);
-  const body = (res?.data ?? {}) as any;
+  const http = (client as CrawlClientLike).http;
+  const res = await http.get(requestPath, ORIGIN_HEADERS);
+  const body = resultRecord(res.data) ?? {};
   const pageDocuments = crawlPageData(body);
-  let current =
-    body.next ??
-    (Array.isArray(body.data) ? null : body.data?.next) ??
-    null;
+  let current = crawlNext(body);
   const usesOffsetWindow = !continuation && !current;
   // Every page is bounded through the same window; a partially shown page is
   // resumed with the same cursor plus an offset instead of being dropped.
@@ -2952,8 +2970,8 @@ async function getCrawlStatusWithOrigin(
     docs.length < CRAWL_MAX_DOCUMENTS &&
     bytes < CRAWL_MAX_BYTES
   ) {
-    const pageRes = await (client as any).http.get(current, ORIGIN_HEADERS);
-    const payload = (pageRes?.data ?? {}) as any;
+    const pageRes = await http.get(current, ORIGIN_HEADERS);
+    const payload = resultRecord(pageRes.data) ?? {};
     if (!payload.success) break;
 
     const pageData = crawlPageData(payload);
@@ -2972,19 +2990,13 @@ async function getCrawlStatusWithOrigin(
         pageHasMore = true;
         partialCursor = String(current);
       } else {
-        current =
-          payload.next ??
-          (Array.isArray(payload.data) ? null : payload.data?.next) ??
-          null;
+        current = crawlNext(payload);
       }
       break;
     }
     docs.push(...pageData);
     bytes += pageBytes;
-    current =
-      payload.next ??
-      (Array.isArray(payload.data) ? null : payload.data?.next) ??
-      null;
+    current = crawlNext(payload);
   }
 
   const result: Record<string, unknown> = {
@@ -3003,18 +3015,20 @@ async function getCrawlStatusWithOrigin(
       ? pageDocuments.length
       : undefined;
   if (pageHasMore) {
-    result._firecrawl = crawlOffsetNotice(
-      jobId,
+    result._firecrawl = crawlWindowNotice(jobId, docs.length, total, {
       offset,
-      docs.length,
-      total,
-      true,
-      partialCursor ?? undefined
-    );
+      hasMore: true,
+      next: partialCursor ?? undefined,
+    });
   } else if (usesOffsetWindow && offset > 0) {
-    result._firecrawl = crawlOffsetNotice(jobId, offset, docs.length, total, false);
+    result._firecrawl = crawlWindowNotice(jobId, docs.length, total, {
+      offset,
+      hasMore: false,
+    });
   } else if (current) {
-    result._firecrawl = crawlCursorNotice(jobId, docs.length, total, String(current));
+    result._firecrawl = crawlWindowNotice(jobId, docs.length, total, {
+      next: current,
+    });
   }
   return result;
 }
@@ -3146,20 +3160,7 @@ Record quality feedback for a prior search ID. A \`good\` rating requires a valu
         .optional()
         .describe('Useful sources from the search; maximum 50.'),
       missingContent: z
-        .array(
-          z.object({
-            topic: z
-              .string()
-              .min(1, 'topic must not be empty')
-              .max(200, 'topic must be 200 characters or fewer')
-              .describe('Short name for the missing topic.'),
-            description: z
-              .string()
-              .max(2000)
-              .optional()
-              .describe('Details about the expected missing content.'),
-          })
-        )
+        .array(missingContentSchema)
         .max(20)
         .optional()
         .describe(
@@ -3851,14 +3852,6 @@ Open or reuse a live browser session to interact with a page by prompt or code. 
         );
       }
     }
-    if (!scrapeId) {
-      throw agentLegibleError(
-        'INTERACT_SESSION_UNAVAILABLE',
-        'Could not open an interact session because scrapeId is missing.',
-        'Call firecrawl_scrape and retry firecrawl_interact with its scrapeId.',
-        session?.requestId
-      );
-    }
     const activeScrapeId = scrapeId;
     log.info('Interacting with page', { scrapeId: activeScrapeId });
     const interactArgs: Record<string, unknown> = { origin: ORIGIN };
@@ -3867,25 +3860,14 @@ Open or reuse a live browser session to interact with a page by prompt or code. 
     if (language) interactArgs.language = language;
     if (timeout != null) interactArgs.timeout = timeout;
     const res = await client.interact(activeScrapeId, interactArgs as any);
-    if (openedFromUrl && res && typeof res === 'object' && !Array.isArray(res)) {
-      return formatToolResponse(
-        {
-          ...(res as unknown as Record<string, unknown>),
-          scrapeId: activeScrapeId,
-        },
-        response_format,
-        'Use a narrower interaction prompt or code output to retrieve omitted content.'
-      );
-    }
-    if (openedFromUrl) {
-      return formatToolResponse(
-        { scrapeId: activeScrapeId, result: res },
-        response_format,
-        'Use a narrower interaction prompt or code output to retrieve omitted content.'
-      );
-    }
+    const result =
+      openedFromUrl && res && typeof res === 'object' && !Array.isArray(res)
+        ? { ...(res as unknown as Record<string, unknown>), scrapeId: activeScrapeId }
+        : openedFromUrl
+          ? { scrapeId: activeScrapeId, result: res }
+          : res;
     return formatToolResponse(
-      res,
+      result,
       response_format,
       'Use a narrower interaction prompt or code output to retrieve omitted content.'
     );
@@ -3952,11 +3934,7 @@ Parse one local or uploaded document into text or structured data; remote web UR
       contentType: overrideContentType,
       response_format = 'detailed',
       ...options
-    } = args as {
-      filePath: string;
-      contentType?: string;
-      response_format?: ResponseFormat;
-    } & Record<string, unknown>;
+    } = args as z.infer<typeof localParseParamsSchema>;
 
     const absPath = path.resolve(filePath);
     const buffer = await readFile(absPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1208,7 +1208,9 @@ function wrapToolError(
       requestId
     );
   }
-  if (/do not support this site/i.test(message)) {
+  // Two permanent domain-policy rejections exist in apps/api: the global
+  // blocklist ("we do not support this site") and org-level threat protection.
+  if (/do not support this site|threat protection policy/i.test(message)) {
     return agentLegibleError(
       'UNSUPPORTED_SITE',
       error,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2863,21 +2863,75 @@ function validatedCrawlContinuation(jobId: string, continuation: string): string
   return `${url.pathname.slice(apiBasePath.length)}${url.search}`;
 }
 
+function takeCrawlDocumentWindow(documents: unknown[], offset: number): unknown[] {
+  const window: unknown[] = [];
+  let bytes = 2;
+  for (const document of documents.slice(offset)) {
+    if (window.length >= CRAWL_MAX_DOCUMENTS) break;
+    const documentBytes = Buffer.byteLength(JSON.stringify(document));
+    if (window.length > 0 && bytes + documentBytes + 1 > CRAWL_MAX_BYTES) break;
+    window.push(document);
+    bytes += documentBytes + (window.length > 1 ? 1 : 0);
+  }
+  return window;
+}
+
+function crawlOffsetNotice(
+  jobId: string,
+  offset: number,
+  shown: number,
+  total: number | undefined,
+  hasMore: boolean
+): Record<string, unknown> {
+  const first = shown > 0 ? offset + 1 : offset;
+  const last = offset + shown;
+  const range = shown > 0 ? `${first}-${last}` : 'empty';
+  const totalText = total == null ? '' : ` of ${total}`;
+  const nextOffset = offset + shown;
+  return {
+    truncated: hasMore,
+    shown_range: { start: first, end: last, ...(total == null ? {} : { total }) },
+    ...(hasMore ? { next_offset: nextOffset } : {}),
+    message: hasMore
+      ? `Shown documents ${range}${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}" and offset: ${nextOffset} to retrieve later documents.`
+      : `Shown documents ${range}${totalText}. All available documents have been returned.`,
+  };
+}
+
+function crawlCursorNotice(
+  jobId: string,
+  shown: number,
+  total: number | undefined,
+  next: string
+): Record<string, unknown> {
+  const totalText = total == null ? '' : ` of ${total} total`;
+  return {
+    truncated: true,
+    shown_range: { start: shown > 0 ? 1 : 0, end: shown, ...(total == null ? {} : { total }) },
+    message: `Shown documents ${shown > 0 ? `1-${shown}` : 'empty'} in this cursor window${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}" and next: "${next}" to retrieve later documents.`,
+  };
+}
+
 async function getCrawlStatusWithOrigin(
   client: FirecrawlApp,
   jobId: string,
-  continuation?: string
+  continuation?: string,
+  offset = 0
 ): Promise<Record<string, unknown>> {
   const requestPath = continuation
     ? validatedCrawlContinuation(jobId, continuation)
     : `/v2/crawl/${encodeURIComponent(jobId)}`;
   const res = await (client as any).http.get(requestPath, ORIGIN_HEADERS);
   const body = (res?.data ?? {}) as any;
-  const docs = crawlPageData(body).slice();
+  const pageDocuments = crawlPageData(body);
   let current =
     body.next ??
     (Array.isArray(body.data) ? null : body.data?.next) ??
     null;
+  const usesOffsetWindow = !continuation && !current;
+  const docs = usesOffsetWindow
+    ? takeCrawlDocumentWindow(pageDocuments, offset)
+    : pageDocuments.slice();
   let bytes = crawlDataBytes(docs);
 
   while (
@@ -2906,7 +2960,7 @@ async function getCrawlStatusWithOrigin(
       null;
   }
 
-  return {
+  const result: Record<string, unknown> = {
     id: jobId,
     status: body.status,
     completed: body.completed ?? 0,
@@ -2916,6 +2970,39 @@ async function getCrawlStatusWithOrigin(
     next: current,
     data: docs,
   };
+  const total = Number.isFinite(Number(body.total))
+    ? Number(body.total)
+    : usesOffsetWindow
+      ? pageDocuments.length
+      : undefined;
+  if (usesOffsetWindow) {
+    const hasMore = offset + docs.length < pageDocuments.length;
+    if (offset > 0 || hasMore) {
+      result._firecrawl = crawlOffsetNotice(
+        jobId,
+        offset,
+        docs.length,
+        total,
+        hasMore
+      );
+    }
+  } else if (current) {
+    result._firecrawl = crawlCursorNotice(jobId, docs.length, total, String(current));
+  }
+  return result;
+}
+
+function crawlResponseGuidance(
+  response: Record<string, unknown>,
+  jobId: string,
+  fallback: string
+): string {
+  const windowMessage = resultRecord(response._firecrawl)?.message;
+  if (typeof windowMessage === 'string') return windowMessage;
+  if (response.next) {
+    return `Call firecrawl_check_crawl_status with id: "${jobId}" and next: "${String(response.next)}" to retrieve later documents; ${fallback}`;
+  }
+  return fallback;
 }
 
 async function waitForCrawlCompletionWithOrigin(
@@ -3323,7 +3410,7 @@ server.addTool({
     destructiveHint: false, // Reads pages from target sites; does not delete or alter external websites.
   },
   description: `
-Start a multi-page website crawl and wait for its terminal state. Use for page content across a site; \`firecrawl_map\` returns only URLs. A returned \`next\` value continues results through \`firecrawl_check_crawl_status\`.
+Start a multi-page website crawl and wait for its terminal state. Use for page content across a site; \`firecrawl_map\` returns only URLs. Truncated results name the exact \`firecrawl_check_crawl_status\` follow-up using an upstream \`next\` cursor or a document \`offset\`.
 `,
   parameters: z.object({
     url: z.string().describe('Website URL where the crawl starts.'),
@@ -3446,9 +3533,11 @@ Start a multi-page website crawl and wait for its terminal state. Use for page c
     return formatToolResponse(
       withResultNotice(res, 'crawl'),
       response_format,
-      res.next
-        ? `Call firecrawl_check_crawl_status with id: "${crawlId}" and next: "${String(res.next)}" to retrieve later documents; narrow scrapeOptions to retrieve omitted document fields.`
-        : 'Narrow scrapeOptions to retrieve omitted document fields.'
+      crawlResponseGuidance(
+        res,
+        crawlId,
+        'Narrow scrapeOptions to retrieve omitted document fields.'
+      )
     );
   },
 });
@@ -3462,7 +3551,7 @@ server.addTool({
     destructiveHint: false, // Status lookup only; no deletes or updates.
   },
   description: `
-Retrieve status and available results for an existing crawl ID without starting or modifying it. Pass a returned \`next\` value with the same ID to retrieve later documents.
+Retrieve status and available results for an existing crawl ID without starting or modifying it. Follow the returned guidance with either an upstream \`next\` cursor or a document \`offset\` to retrieve later documents.
 `,
   parameters: z.object({
     id: z.string().min(1).describe('Crawl job ID.'),
@@ -3470,7 +3559,17 @@ Retrieve status and available results for an existing crawl ID without starting 
       .string()
       .max(4_096)
       .optional()
-      .describe('Continuation URL returned by a previous status call.'),
+      .describe(
+        'Upstream continuation URL returned by a previous status call; takes precedence over offset when both are supplied.'
+      ),
+    offset: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        'Zero-based document offset returned in prior guidance for a single-page result. The next cursor takes precedence when both are supplied.'
+      ),
     response_format: responseFormatSchema,
   }),
   execute: async (
@@ -3481,19 +3580,23 @@ Retrieve status and available results for an existing crawl ID without starting 
     const {
       id,
       next,
+      offset = 0,
       response_format = 'detailed',
     } = args as {
       id: string;
       next?: string;
+      offset?: number;
       response_format?: ResponseFormat;
     };
-    const res = await getCrawlStatusWithOrigin(client, id, next);
+    const res = await getCrawlStatusWithOrigin(client, id, next, next ? 0 : offset);
     return formatToolResponse(
       withResultNotice(res, 'crawl'),
       response_format,
-      res.next
-        ? `Call firecrawl_check_crawl_status with id: "${id}" and next: "${String(res.next)}" to retrieve later documents; narrow the crawl request to retrieve omitted document fields.`
-        : 'Narrow the crawl request to retrieve omitted document fields.'
+      crawlResponseGuidance(
+        res,
+        id,
+        'Narrow the crawl request to retrieve omitted document fields.'
+      )
     );
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -893,6 +893,10 @@ const openAiAppsChallengeToken = normalizeHeader(
 
 const FULL_PROFILE_INSTRUCTIONS = `Firecrawl provides web search, page retrieval, site URL discovery, multi-page collection, structured page data, monitoring, and asynchronous research. Match the requested operation to the tool boundary: firecrawl_scrape retrieves one supplied page and can return JSON matching a supplied schema, firecrawl_map enumerates URLs under a site without retrieving their content, and firecrawl_agent starts multi-source research whose result is read with firecrawl_agent_status. For biomedical, life-science, clinical, or arXiv literature, the firecrawl_research_* tools search a paper index of abstracts and full text; firecrawl_search with categories: ["research"] is a website filter over ordinary web results and reaches different sources. For a programming question — code behaviour, a library or framework, an API contract, an error message, or a known bug — firecrawl_developer_search (or firecrawl_search with categories: ["developer"]) searches an index of GitHub issues, merged pull requests, READMEs, and curated documentation sites. Provide only the required inputs and account for stated network or external side effects.`;
 const KEYLESS_PROFILE_INSTRUCTIONS = `Without authentication, this endpoint exposes Search, Scrape, and Parse with usage limits. An OAuth connection or Authorization bearer API key exposes account tools; unavailable tools return connection guidance. Firecrawl provides web search, page retrieval, site URL discovery, multi-page collection, structured page data, monitoring, and asynchronous research. Match the requested operation to the tool boundary: firecrawl_scrape retrieves one supplied page and can return JSON matching a supplied schema, firecrawl_map enumerates URLs under a site without retrieving their content, and firecrawl_agent starts multi-source research whose result is read with firecrawl_agent_status. For biomedical, life-science, clinical, or arXiv literature, firecrawl_search with categories: ["research"] filters ordinary web results to research-affiliated websites; the firecrawl_research_* tools search a separate paper index of abstracts and full text and become available once an OAuth connection or Authorization bearer API key is present. Provide only the required inputs.`;
+const LOCAL_KEYLESS_PROFILE_INSTRUCTIONS = KEYLESS_PROFILE_INSTRUCTIONS.replace(
+  'Search, Scrape, and Parse',
+  'Search and Scrape'
+);
 
 // The search surface exposes web/research search only. Its instructions and tool
 // copy describe just those tools and stay neutral about how a client uses them.
@@ -915,7 +919,11 @@ function makeFullProfile(): ServerProfile {
   return {
     id: account ? 'account' : 'full',
     resourceName: account ? 'Firecrawl MCP Account' : 'Firecrawl MCP',
-    instructions: account ? FULL_PROFILE_INSTRUCTIONS : KEYLESS_PROFILE_INSTRUCTIONS,
+    instructions: account
+      ? FULL_PROFILE_INSTRUCTIONS
+      : isLocalKeylessStartup()
+        ? LOCAL_KEYLESS_PROFILE_INSTRUCTIONS
+        : KEYLESS_PROFILE_INSTRUCTIONS,
     resourceUrl: account
       ? normalizeHeader(process.env.FIRECRAWL_MCP_RESOURCE_URL) ??
         DEFAULT_MCP_OAUTH_RESOURCE_URL
@@ -1001,9 +1009,12 @@ const primaryProfile = makePrimaryProfile();
 const server = createServer(primaryProfile);
 type RegisteredTool = Parameters<typeof server.addTool>[0];
 
-const KEYLESS_TOOL_NAMES = new Set([
+const LOCAL_KEYLESS_TOOL_NAMES = new Set([
   'firecrawl_scrape',
   'firecrawl_search',
+]);
+const KEYLESS_TOOL_NAMES = new Set([
+  ...LOCAL_KEYLESS_TOOL_NAMES,
   'firecrawl_parse',
 ]);
 
@@ -1015,8 +1026,17 @@ function isHostedKeylessSession(session?: SessionData): boolean {
   );
 }
 
+function isLocalKeylessSession(session?: SessionData): boolean {
+  return (
+    isLocalKeylessStartup() &&
+    session?.authType === 'none' &&
+    !session.firecrawlApiKey
+  );
+}
+
 // A stdio client without a cloud credential can use only the keyless tools.
-// Do this at registration time so unsupported feedback tools are not advertised.
+// Registration-time checks keep unavailable feedback tools out of this surface;
+// the shared canList boundary below filters the remaining account-only tools.
 function isLocalKeylessStartup(): boolean {
   return (
     process.env.CLOUD_SERVICE !== 'true' &&
@@ -1268,6 +1288,7 @@ function guardHostedTool(
   { logActions }: { logActions: boolean }
 ): RegisteredTool {
   const keylessTool = KEYLESS_TOOL_NAMES.has(tool.name);
+  const localKeylessTool = LOCAL_KEYLESS_TOOL_NAMES.has(tool.name);
   const execute = tool.execute;
   const canList = tool.canList;
   const beforeValidate = tool.beforeValidate;
@@ -1283,7 +1304,9 @@ function guardHostedTool(
       // to a request carrying an unrecognized or invalid credential.
       (session?.credentialError || isHostedKeylessSession(session)
         ? keylessTool
-        : true) &&
+        : isLocalKeylessSession(session)
+          ? localKeylessTool
+          : true) &&
       (canList?.(session) ?? true),
     beforeValidate: async (args: unknown, session: SessionData) => {
       const code = session?.credentialError

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { registerDeveloperTools } from './developer';
 import { extractSingleTrustedClientIp } from './keyless-client-ip';
 import { registerMonitorTools } from './monitor';
-import { registerResearchTools } from './research';
+import { type ClientLike, registerResearchTools } from './research';
 import { escapeWWWAuthenticateValue } from './www-authenticate';
 import {
   credentialForOutboundRequest,
@@ -1729,7 +1729,7 @@ function truncationMetadata(
   return {
     truncated: true,
     omitted,
-    message: `Response truncated; omitted ${omitted.fields} fields, ${omitted.array_items} array items, and ${omitted.characters} characters. ${guidance.slice(0, 2_000)}`.trim(),
+    message: `Response truncated; omitted ${omitted.fields} fields, ${omitted.array_items} array items, and ${omitted.characters} characters. ${guidance}`.trim(),
   };
 }
 
@@ -1804,10 +1804,6 @@ function withResultNotice(
     case 'agent':
       empty = Object.keys(body).length === 0;
       break;
-    default: {
-      const _exhaustive: never = kind;
-      return _exhaustive;
-    }
   }
   if (!blocked && !empty) return data;
 
@@ -2849,15 +2845,6 @@ async function keylessPost(
   return json;
 }
 
-type CrawlClientLike = {
-  http: {
-    get: <T = unknown>(
-      endpoint: string,
-      headers?: Record<string, string>
-    ) => Promise<{ data: T; status: number }>;
-  };
-};
-
 function crawlPageData(body: unknown): unknown[] {
   const data = resultRecord(body)?.data;
   if (Array.isArray(data)) return data;
@@ -2890,13 +2877,13 @@ function validatedCrawlContinuation(jobId: string, continuation: string): string
 
 function takeCrawlDocumentWindow(documents: unknown[], offset: number): unknown[] {
   const window: unknown[] = [];
-  let bytes = 2;
+  let bytes = 0;
   for (const document of documents.slice(offset)) {
     if (window.length >= CRAWL_MAX_DOCUMENTS) break;
     const documentBytes = Buffer.byteLength(JSON.stringify(document));
-    if (window.length > 0 && bytes + documentBytes + 1 > CRAWL_MAX_BYTES) break;
+    if (window.length > 0 && bytes + documentBytes > CRAWL_MAX_BYTES) break;
     window.push(document);
-    bytes += documentBytes + (window.length > 1 ? 1 : 0);
+    bytes += documentBytes;
   }
   return window;
 }
@@ -2963,7 +2950,7 @@ async function getCrawlStatusWithOrigin(
   const requestPath = continuation
     ? validatedCrawlContinuation(jobId, continuation)
     : `/v2/crawl/${encodeURIComponent(jobId)}`;
-  const http = (client as CrawlClientLike).http;
+  const http = (client as ClientLike).http;
   const res = await http.get(requestPath, ORIGIN_HEADERS);
   const body = resultRecord(res.data) ?? {};
   const pageDocuments = crawlPageData(body);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1180,9 +1180,13 @@ class InvalidCrawlContinuationError extends Error {
 // Tools whose failed calls may already have produced external side effects (a
 // submitted form, a created monitor). Unclassified failures on these must not
 // advertise retryable: an obedient agent would repeat the side effect.
+// Update/delete are excluded: repeating them converges on the same target
+// state. Run and feedback POSTs create a new run / a new record each time.
 const NON_IDEMPOTENT_TOOLS = new Set([
   'firecrawl_interact',
   'firecrawl_monitor_create',
+  'firecrawl_monitor_run',
+  'firecrawl_feedback',
 ]);
 
 function wrapToolError(
@@ -1207,6 +1211,13 @@ function wrapToolError(
       'If other Firecrawl tools succeed, this failure may be limited to this operation: retry once or accomplish the step with another Firecrawl tool such as firecrawl_scrape. Otherwise configure a Firecrawl API key or set FIRECRAWL_API_URL for a self-hosted instance, then start a new session and retry.',
       requestId
     );
+  const unsupportedSiteError = () =>
+    agentLegibleError(
+      'UNSUPPORTED_SITE',
+      error,
+      'Firecrawl declines this site by policy, so the same URL will always fail. Use a different source or tool for this content.',
+      requestId
+    );
   const upstreamTimeoutError = () =>
     agentLegibleError(
       'UPSTREAM_TIMEOUT',
@@ -1223,6 +1234,12 @@ function wrapToolError(
   if (status === 401) return authRequiredError();
   if (status === 408 || code === 'SCRAPE_TIMEOUT') {
     return upstreamTimeoutError();
+  }
+  // Threat-protection blocks have a stable API code (apps/api keeps
+  // "unsafe_domain_blocked" for API stability); the message text can be
+  // reworded, so prefer the code over the regex below.
+  if (code === 'unsafe_domain_blocked') {
+    return unsupportedSiteError();
   }
   if (status === 429) {
     const details = resultRecord(sdkError?.details);
@@ -1259,12 +1276,7 @@ function wrapToolError(
   // Two permanent domain-policy rejections exist in apps/api: the global
   // blocklist ("we do not support this site") and org-level threat protection.
   if (/do not support this site|threat protection policy/i.test(message)) {
-    return agentLegibleError(
-      'UNSUPPORTED_SITE',
-      error,
-      'Firecrawl declines this site by policy, so the same URL will always fail. Use a different source or tool for this content.',
-      requestId
-    );
+    return unsupportedSiteError();
   }
   if (/timed? out|timeout/i.test(message)) {
     return upstreamTimeoutError();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2889,19 +2889,21 @@ function crawlOffsetNotice(
   offset: number,
   shown: number,
   total: number | undefined,
-  hasMore: boolean
+  hasMore: boolean,
+  next?: string
 ): Record<string, unknown> {
   const first = shown > 0 ? offset + 1 : offset;
   const last = offset + shown;
   const range = shown > 0 ? `${first}-${last}` : 'empty';
   const totalText = total == null ? '' : ` of ${total}`;
   const nextOffset = offset + shown;
+  const nextArg = next == null ? '' : `, next: "${next}"`;
   return {
     truncated: hasMore,
     shown_range: { start: first, end: last, ...(total == null ? {} : { total }) },
-    ...(hasMore ? { next_offset: nextOffset } : {}),
+    ...(hasMore ? { next_offset: nextOffset, ...(next == null ? {} : { next }) } : {}),
     message: hasMore
-      ? `Shown documents ${range}${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}" and offset: ${nextOffset} to retrieve later documents.`
+      ? `Shown documents ${range}${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}"${nextArg} and offset: ${nextOffset} to retrieve later documents.`
       : `Shown documents ${range}${totalText}. All available documents have been returned.`,
   };
 }
@@ -2937,12 +2939,15 @@ async function getCrawlStatusWithOrigin(
     (Array.isArray(body.data) ? null : body.data?.next) ??
     null;
   const usesOffsetWindow = !continuation && !current;
-  const docs = usesOffsetWindow
-    ? takeCrawlDocumentWindow(pageDocuments, offset)
-    : pageDocuments.slice();
+  // Every page is bounded through the same window; a partially shown page is
+  // resumed with the same cursor plus an offset instead of being dropped.
+  const docs = takeCrawlDocumentWindow(pageDocuments, offset);
   let bytes = crawlDataBytes(docs);
+  let pageHasMore = offset + docs.length < pageDocuments.length;
+  let partialCursor: string | null = continuation ?? null;
 
   while (
+    !pageHasMore &&
     current &&
     docs.length < CRAWL_MAX_DOCUMENTS &&
     bytes < CRAWL_MAX_BYTES
@@ -2954,10 +2959,24 @@ async function getCrawlStatusWithOrigin(
     const pageData = crawlPageData(payload);
     const pageBytes = crawlDataBytes(pageData);
     if (
-      docs.length > 0 &&
-      (docs.length + pageData.length > CRAWL_MAX_DOCUMENTS ||
-        bytes + pageBytes > CRAWL_MAX_BYTES)
+      docs.length + pageData.length > CRAWL_MAX_DOCUMENTS ||
+      bytes + pageBytes > CRAWL_MAX_BYTES
     ) {
+      if (docs.length > 0) break;
+      // Nothing shown yet: take what fits from this page so the call returns
+      // progress instead of an empty result.
+      const window = takeCrawlDocumentWindow(pageData, 0);
+      docs.push(...window);
+      bytes += crawlDataBytes(window);
+      if (window.length < pageData.length) {
+        pageHasMore = true;
+        partialCursor = String(current);
+      } else {
+        current =
+          payload.next ??
+          (Array.isArray(payload.data) ? null : payload.data?.next) ??
+          null;
+      }
       break;
     }
     docs.push(...pageData);
@@ -2975,7 +2994,7 @@ async function getCrawlStatusWithOrigin(
     total: body.total ?? 0,
     creditsUsed: body.creditsUsed,
     expiresAt: body.expiresAt,
-    next: current,
+    next: pageHasMore ? partialCursor : current,
     data: docs,
   };
   const total = Number.isFinite(Number(body.total))
@@ -2983,17 +3002,17 @@ async function getCrawlStatusWithOrigin(
     : usesOffsetWindow
       ? pageDocuments.length
       : undefined;
-  if (usesOffsetWindow) {
-    const hasMore = offset + docs.length < pageDocuments.length;
-    if (offset > 0 || hasMore) {
-      result._firecrawl = crawlOffsetNotice(
-        jobId,
-        offset,
-        docs.length,
-        total,
-        hasMore
-      );
-    }
+  if (pageHasMore) {
+    result._firecrawl = crawlOffsetNotice(
+      jobId,
+      offset,
+      docs.length,
+      total,
+      true,
+      partialCursor ?? undefined
+    );
+  } else if (usesOffsetWindow && offset > 0) {
+    result._firecrawl = crawlOffsetNotice(jobId, offset, docs.length, total, false);
   } else if (current) {
     result._firecrawl = crawlCursorNotice(jobId, docs.length, total, String(current));
   }
@@ -3568,7 +3587,7 @@ Retrieve status and available results for an existing crawl ID without starting 
       .max(4_096)
       .optional()
       .describe(
-        'Upstream continuation URL returned by a previous status call; takes precedence over offset when both are supplied.'
+        'Upstream continuation URL returned by a previous status call; combine with offset when prior guidance shows a partially returned page.'
       ),
     offset: z
       .number()
@@ -3576,7 +3595,7 @@ Retrieve status and available results for an existing crawl ID without starting 
       .nonnegative()
       .optional()
       .describe(
-        'Zero-based document offset returned in prior guidance for a single-page result. The next cursor takes precedence when both are supplied.'
+        'Zero-based document offset returned in prior guidance, applied within the page being retrieved.'
       ),
     response_format: responseFormatSchema,
   }),
@@ -3596,7 +3615,7 @@ Retrieve status and available results for an existing crawl ID without starting 
       offset?: number;
       response_format?: ResponseFormat;
     };
-    const res = await getCrawlStatusWithOrigin(client, id, next, next ? 0 : offset);
+    const res = await getCrawlStatusWithOrigin(client, id, next, offset);
     return formatToolResponse(
       withResultNotice(res, 'crawl'),
       response_format,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1135,6 +1135,7 @@ type ToolErrorCode =
   | 'FILE_NOT_FOUND'
   | 'UNSUPPORTED_SITE'
   | 'UPSTREAM_TIMEOUT'
+  | 'RATE_LIMITED'
   | 'INVALID_REQUEST'
   | 'UPSTREAM_REQUEST_FAILED'
   | 'CRAWL_START_FAILED'
@@ -1192,13 +1193,60 @@ function wrapToolError(
   const safeToRepeat = !NON_IDEMPOTENT_TOOLS.has(toolName ?? '');
   if (error instanceof UserError) return error;
   const message = errorText(error);
-  if (/unauthori[sz]ed|api key|credentials? required/i.test(message)) {
-    return agentLegibleError(
+  const sdkError =
+    typeof error === 'object' && error !== null
+      ? (error as { code?: unknown; details?: unknown; status?: unknown })
+      : undefined;
+  const status =
+    typeof sdkError?.status === 'number' ? sdkError.status : undefined;
+  const code = typeof sdkError?.code === 'string' ? sdkError.code : undefined;
+  const authRequiredError = () =>
+    agentLegibleError(
       'AUTH_REQUIRED',
       error,
       'If other Firecrawl tools succeed, this failure may be limited to this operation: retry once or accomplish the step with another Firecrawl tool such as firecrawl_scrape. Otherwise configure a Firecrawl API key or set FIRECRAWL_API_URL for a self-hosted instance, then start a new session and retry.',
       requestId
     );
+  const upstreamTimeoutError = () =>
+    agentLegibleError(
+      'UPSTREAM_TIMEOUT',
+      error,
+      safeToRepeat
+        ? 'Retry once with a narrower request or a longer supported timeout; if the job ID is known, check its status instead of starting a duplicate job.'
+        : 'The action may have taken effect despite the timeout. Verify the current state (re-check the page or list existing monitors) before repeating it.',
+      requestId,
+      safeToRepeat
+    );
+
+  // SDK errors carry stable transport metadata; classify it before falling
+  // back to message text for raw fetch paths and locally-thrown errors.
+  if (status === 401) return authRequiredError();
+  if (status === 408 || code === 'SCRAPE_TIMEOUT') {
+    return upstreamTimeoutError();
+  }
+  if (status === 429) {
+    const details = resultRecord(sdkError?.details);
+    const detailSeconds = Number(details?.retry_after_seconds);
+    const messageSeconds = /retry after\s+(\d+)\s*s/i.exec(message)?.[1];
+    const retryAfterSeconds =
+      Number.isFinite(detailSeconds) && detailSeconds > 0
+        ? detailSeconds
+        : messageSeconds
+          ? Number(messageSeconds)
+          : undefined;
+    // A 429 is rejected before tool execution, so retryability is safe even
+    // for tools whose successful calls may have external side effects.
+    return agentLegibleError(
+      'RATE_LIMITED',
+      error,
+      `${retryAfterSeconds ? `Wait ${retryAfterSeconds} seconds` : 'Wait'} before retrying, and avoid parallel Firecrawl calls to reduce repeated rate-limit failures.`,
+      requestId,
+      true
+    );
+  }
+
+  if (/unauthori[sz]ed|api key|credentials? required/i.test(message)) {
+    return authRequiredError();
   }
   if (/ENOENT|no such file/i.test(message)) {
     return agentLegibleError(
@@ -1219,15 +1267,7 @@ function wrapToolError(
     );
   }
   if (/timed? out|timeout/i.test(message)) {
-    return agentLegibleError(
-      'UPSTREAM_TIMEOUT',
-      error,
-      safeToRepeat
-        ? 'Retry once with a narrower request or a longer supported timeout; if the job ID is known, check its status instead of starting a duplicate job.'
-        : 'The action may have taken effect despite the timeout. Verify the current state (re-check the page or list existing monitors) before repeating it.',
-      requestId,
-      safeToRepeat
-    );
+    return upstreamTimeoutError();
   }
   if (error instanceof InvalidCrawlContinuationError) {
     return agentLegibleError(
@@ -2851,7 +2891,7 @@ function takeCrawlDocumentWindow(documents: unknown[], offset: number): unknown[
 
 type CrawlNoticeContinuation =
   | { offset: number; hasMore: boolean; next?: string }
-  | { next: string };
+  | { next: string; shownFrom?: number };
 
 function crawlWindowNotice(
   jobId: string,
@@ -2884,14 +2924,21 @@ function crawlWindowNotice(
   }
 
   const totalText = total == null ? '' : ` of ${total} total`;
+  // A manual offset shifts the absolute position of the shown documents even
+  // when the resume path is a cursor; the displayed range must reflect it.
+  const base = continuation.shownFrom ?? 0;
+  const first = base + (shown > 0 ? 1 : 0);
+  const last = base + shown;
+  const range = shown > 0 ? `${first}-${last}` : 'empty';
   return {
     truncated: true,
     shown_range: {
-      start: shown > 0 ? 1 : 0,
-      end: shown,
+      start: first,
+      end: last,
       ...(total == null ? {} : { total }),
     },
-    message: `Shown documents ${shown > 0 ? `1-${shown}` : 'empty'} in this cursor window${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}" and next: "${continuation.next}" to retrieve later documents.`,
+    next: continuation.next,
+    message: `Shown documents ${range} in this cursor window${totalText}. Call firecrawl_check_crawl_status with id: "${jobId}" and next: "${continuation.next}" to retrieve later documents.`,
   };
 }
 
@@ -2952,6 +2999,12 @@ async function getCrawlStatusWithOrigin(
     current = crawlNext(payload);
   }
 
+  const synthesizedCursor =
+    pageHasMore && partialCursor === null
+      ? `${resolveApiBaseUrl()}/v2/crawl/${encodeURIComponent(jobId)}?skip=${offset + docs.length}`
+      : undefined;
+  if (synthesizedCursor) partialCursor = synthesizedCursor;
+
   const result: Record<string, unknown> = {
     id: jobId,
     status: body.status,
@@ -2968,11 +3021,16 @@ async function getCrawlStatusWithOrigin(
       ? pageDocuments.length
       : undefined;
   if (pageHasMore) {
-    result._firecrawl = crawlWindowNotice(jobId, docs.length, total, {
-      offset,
-      hasMore: true,
-      next: partialCursor ?? undefined,
-    });
+    result._firecrawl = synthesizedCursor
+      ? crawlWindowNotice(jobId, docs.length, total, {
+          next: synthesizedCursor,
+          shownFrom: offset,
+        })
+      : crawlWindowNotice(jobId, docs.length, total, {
+          offset,
+          hasMore: true,
+          next: partialCursor ?? undefined,
+        });
   } else if (usesOffsetWindow && offset > 0) {
     result._firecrawl = crawlWindowNotice(jobId, docs.length, total, {
       offset,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1201,6 +1201,14 @@ function wrapToolError(error: unknown, requestId: string): UserError {
       requestId
     );
   }
+  if (/do not support this site/i.test(message)) {
+    return agentLegibleError(
+      'UNSUPPORTED_SITE',
+      error,
+      'Firecrawl declines this site by policy, so the same URL will always fail. Use a different source or tool for this content.',
+      requestId
+    );
+  }
   if (/timed? out|timeout/i.test(message)) {
     return agentLegibleError(
       'UPSTREAM_TIMEOUT',

--- a/src/index.ts
+++ b/src/index.ts
@@ -807,6 +807,12 @@ function buildSearchQueryWithDomains(
   return query;
 }
 
+type ResponseFormat = 'concise' | 'detailed';
+
+const responseFormatSchema = z
+  .enum(['concise', 'detailed'])
+  .default('detailed');
+
 // Parameter fields shared by both firecrawl_search surfaces. The full surface
 // adds `scrapeOptions` on top; the search surface uses these as-is (strict, no
 // scrapeOptions). Defining the field set once keeps the two surfaces from
@@ -835,6 +841,7 @@ const searchToolBaseFields = {
       'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` restricts ordinary web results to research-affiliated websites and returns page snippets, which is separate from the `firecrawl_research_*` tools that search paper abstracts and full text across biomedical (PubMed, bioRxiv, medRxiv) and arXiv literature; `pdf` searches PDF results; `developer` searches an index built for coding agents over GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. `developer` adds a `data.developer` group of `{ url, title, description }` results, where `description` holds the matched passage; the other categories filter `data.web`.'
     ),
   enterprise: z.array(z.enum(['default', 'anon', 'zdr'])).optional(),
+  response_format: responseFormatSchema,
 };
 
 // Both surfaces forbid specifying includeDomains and excludeDomains together.
@@ -1404,6 +1411,149 @@ function asText(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
 
+type TruncationStats = {
+  arrayItems: number;
+  characters: number;
+  fields: number;
+};
+
+// Detailed stays compatible for ordinary payloads; both ceilings prevent one
+// tool result from consuming an agent's context window (~3k/~16k tokens).
+const CONCISE_RESPONSE_MAX_CHARS = 12_000;
+const DETAILED_RESPONSE_MAX_CHARS = 64_000;
+const CRAWL_MAX_DOCUMENTS = 25;
+const CRAWL_MAX_BYTES = 48_000;
+
+const conciseOmittedFields = /(?:base64|screenshot)/i;
+
+function compactResponseValue(
+  value: unknown,
+  limits: { arrayItems: number; objectFields: number; stringChars: number },
+  stats: TruncationStats,
+  concise: boolean,
+  depth = 0
+): unknown {
+  if (typeof value === 'string') {
+    if (value.length <= limits.stringChars) return value;
+    stats.characters += value.length - limits.stringChars;
+    return `${value.slice(0, limits.stringChars)}\n[truncated ${value.length - limits.stringChars} characters]`;
+  }
+  if (!value || typeof value !== 'object') return value;
+  if (depth >= 12) {
+    stats.fields += 1;
+    return '[truncated nested value]';
+  }
+  if (Array.isArray(value)) {
+    const retained = value.slice(0, limits.arrayItems);
+    stats.arrayItems += value.length - retained.length;
+    return retained.map((item) =>
+      compactResponseValue(item, limits, stats, concise, depth + 1)
+    );
+  }
+
+  const record = value as Record<string, unknown>;
+  const hasMarkdown = typeof record.markdown === 'string' && record.markdown.length > 0;
+  const entries = Object.entries(record).filter(([key]) => {
+    const omit =
+      concise &&
+      (conciseOmittedFields.test(key) || (key === 'rawHtml' && hasMarkdown));
+    if (omit) stats.fields += 1;
+    return !omit;
+  });
+  const retained = entries.slice(0, limits.objectFields);
+  stats.fields += entries.length - retained.length;
+  return Object.fromEntries(
+    retained.map(([key, item]) => [
+      key,
+      compactResponseValue(item, limits, stats, concise, depth + 1),
+    ])
+  );
+}
+
+function truncationMetadata(
+  format: ResponseFormat,
+  stats: TruncationStats,
+  guidance: string
+): Record<string, unknown> {
+  const omitted = {
+    fields: stats.fields,
+    array_items: stats.arrayItems,
+    characters: stats.characters,
+  };
+  const detailGuidance =
+    format === 'concise'
+      ? 'Use response_format: "detailed" to include fields omitted by concise format. '
+      : '';
+  return {
+    truncated: true,
+    response_format: format,
+    omitted,
+    message: `Response truncated; omitted ${omitted.fields} fields, ${omitted.array_items} array items, and ${omitted.characters} characters. ${detailGuidance}${guidance.slice(0, 2_000)}`.trim(),
+  };
+}
+
+function withTruncationMetadata(
+  value: unknown,
+  metadata: Record<string, unknown>
+): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? { ...(value as Record<string, unknown>), _firecrawl: metadata }
+    : { result: value, _firecrawl: metadata };
+}
+
+function formatToolResponse(
+  data: unknown,
+  format: ResponseFormat,
+  guidance: string
+): string {
+  const maxChars =
+    format === 'concise'
+      ? CONCISE_RESPONSE_MAX_CHARS
+      : DETAILED_RESPONSE_MAX_CHARS;
+  if (format === 'detailed') {
+    const unchanged = asText(data);
+    if (unchanged.length <= maxChars) return unchanged;
+  }
+
+  let limits =
+    format === 'concise'
+      ? { arrayItems: 8, objectFields: 30, stringChars: 2_000 }
+      : { arrayItems: 50, objectFields: 100, stringChars: 12_000 };
+  for (;;) {
+    const stats: TruncationStats = { arrayItems: 0, characters: 0, fields: 0 };
+    const compacted = compactResponseValue(
+      data,
+      limits,
+      stats,
+      format === 'concise'
+    );
+    const hadOmissions =
+      stats.arrayItems > 0 || stats.characters > 0 || stats.fields > 0;
+    if (!hadOmissions) return asText(compacted);
+    const output = asText(
+      withTruncationMetadata(
+        compacted,
+        truncationMetadata(format, stats, guidance)
+      )
+    );
+    if (output.length <= maxChars) return output;
+    if (
+      limits.arrayItems === 1 &&
+      limits.objectFields === 1 &&
+      limits.stringChars === 128
+    ) {
+      return asText({
+        _firecrawl: truncationMetadata(format, stats, guidance),
+      });
+    }
+    limits = {
+      arrayItems: Math.max(1, Math.floor(limits.arrayItems / 2)),
+      objectFields: Math.max(1, Math.floor(limits.objectFields / 2)),
+      stringChars: Math.max(128, Math.floor(limits.stringChars / 2)),
+    };
+  }
+}
+
 // scrape tool (v2 semantics, minimal args)
 // Centralized scrape params (used by scrape, and referenced in search/crawl scrapeOptions)
 
@@ -1481,6 +1631,7 @@ function transformScrapeParams(
   args: Record<string, unknown>
 ): Record<string, unknown> {
   const out = { ...args };
+  delete out.response_format;
 
   const formats = buildFormatsArray(out);
   if (formats) out.formats = formats;
@@ -1583,6 +1734,7 @@ const scrapeParamsSchema = z.object({
       saveChanges: z.boolean().optional(),
     })
     .optional(),
+  response_format: responseFormatSchema,
 });
 
 const parseOptionParamsSchema = z.object({
@@ -1630,6 +1782,7 @@ const parseOptionParamsSchema = z.object({
     .optional()
     .describe('Ignored: parse never reuses or stores indexed content.'),
   proxy: z.enum(['basic', 'auto']).optional(),
+  response_format: responseFormatSchema,
 });
 
 const localParseParamsSchema = parseOptionParamsSchema.extend({
@@ -1730,6 +1883,7 @@ function extractParseOptions(args: ParseToolArgs): Record<string, unknown> {
   delete options.uploadRef;
   delete options.contentType;
   delete options.declaredSizeBytes;
+  delete options.response_format;
   return options;
 }
 
@@ -1743,11 +1897,13 @@ function buildParseOptionsPayload(
 
 function buildContinuationArguments(
   uploadRef: string,
-  options: Record<string, unknown>
+  options: Record<string, unknown>,
+  responseFormat: ResponseFormat
 ): Record<string, unknown> {
   return {
     uploadRef,
     ...(removeEmptyTopLevel(options) as Record<string, unknown>),
+    response_format: responseFormat,
   };
 }
 
@@ -1889,6 +2045,7 @@ async function executeHostedParse(
     throw new UserError(String(payload.message), payload);
   }
 
+  const responseFormat = (args.response_format ?? 'detailed') as ResponseFormat;
   const options = extractParseOptions(args);
 
   if (hasFilePath && args.filePath) {
@@ -1923,9 +2080,10 @@ async function executeHostedParse(
           : { 'Content-Type': contentType };
     const uploadForCommand = { ...upload, headers: uploadHeaders };
 
-    return asText({
-      success: true,
-      mode: 'hosted-upload-ref-awaiting-upload',
+    return formatToolResponse(
+      {
+        success: true,
+        mode: 'hosted-upload-ref-awaiting-upload',
       message:
         'Hosted MCP cannot read local files. Run the local upload command, then call firecrawl_parse again with uploadRef. No Firecrawl API key is included in this command.',
       upload: {
@@ -1940,14 +2098,21 @@ async function executeHostedParse(
       },
       nextToolCall: {
         name: 'firecrawl_parse',
-        arguments: buildContinuationArguments(upload.uploadRef, options),
+        arguments: buildContinuationArguments(
+          upload.uploadRef,
+          options,
+          responseFormat
+        ),
       },
-      notes: [
-        'Run the curl command on the machine that can read filePath.',
-        'After the PUT succeeds, use nextToolCall as the second MCP tool call.',
-        'Clients without a local upload mechanism cannot complete hosted parse for local files.',
-      ],
-    });
+        notes: [
+          'Run the curl command on the machine that can read filePath.',
+          'After the PUT succeeds, use nextToolCall as the second MCP tool call.',
+          'Clients without a local upload mechanism cannot complete hosted parse for local files.',
+        ],
+      },
+      responseFormat,
+      'Use a shorter file path and fewer parse options to retrieve omitted upload instructions.'
+    );
   }
 
   const parsePayload = {
@@ -1960,7 +2125,11 @@ async function executeHostedParse(
     parsePayload,
     session
   );
-  return asText(parseJson);
+  return formatToolResponse(
+    parseJson,
+    responseFormat,
+    'Parse fewer pages or request fewer output formats to retrieve the omitted content.'
+  );
 }
 
 server.addTool({
@@ -1978,14 +2147,14 @@ This tool operates on a known page. For a set of pages use \`firecrawl_crawl\`, 
 
 Firecrawl may reuse recently indexed content instead of refetching the page, and the reuse window varies by domain. Set \`maxAge: 0\` to force a live fetch, or a smaller \`maxAge\` to bound how stale reused content may be. A successful response does not by itself confirm that the state it describes is still current.
 
-Returns the selected content formats and page metadata.
+Returns the selected content formats and page metadata. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate formats, while both formats bound oversized responses and report omissions in-band.
 `,
   parameters: scrapeParamsSchema,
   execute: async (args: unknown, { session, log }): Promise<string> => {
-    const { url, ...options } = args as { url: string } & Record<
-      string,
-      unknown
-    >;
+    const { url, response_format = 'detailed', ...options } = args as {
+      url: string;
+      response_format?: ResponseFormat;
+    } & Record<string, unknown>;
     const transformed = transformScrapeParams(
       options as Record<string, unknown>
     );
@@ -2005,14 +2174,22 @@ Returns the selected content formats and page metadata.
         },
         session
       );
-      return asText(json?.data ?? json);
+      return formatToolResponse(
+        json?.data ?? json,
+        response_format,
+        'Request fewer formats or narrow the extraction to retrieve omitted page content.'
+      );
     }
     const client = getClient(session);
     const res = await client.scrape(String(url), {
       ...cleaned,
       origin: ORIGIN,
     } as any);
-    return asText(res);
+    return formatToolResponse(
+      res,
+      response_format,
+      'Request fewer formats or narrow the extraction to retrieve omitted page content.'
+    );
   },
 });
 
@@ -2049,7 +2226,11 @@ Returns matching URLs rather than page bodies. Retrieve one page with \`firecraw
       ...cleaned,
       origin: ORIGIN,
     } as any);
-    return asText(res);
+    return formatToolResponse(
+      res,
+      'detailed',
+      'Retry firecrawl_map with a lower limit or narrower search term to retrieve omitted URLs.'
+    );
   },
 });
 
@@ -2068,19 +2249,22 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
 
 \`categories: ["research"]\` restricts these web results to research-affiliated websites and returns page snippets. The \`firecrawl_research_*\` tools are a separate surface that searches paper abstracts and full text across biomedical (PubMed, bioRxiv, medRxiv) and arXiv literature.
 
-\`scrapeOptions\` can attach extracted page content; pages fetched this way use a fixed reuse window and ignore \`maxAge\`, so use \`firecrawl_scrape\` when a live fetch is required. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback.
+\`scrapeOptions\` can attach extracted page content; pages fetched this way use a fixed reuse window and ignore \`maxAge\`, so use \`firecrawl_scrape\` when a live fetch is required. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
 `,
   parameters: z
     .object({
       ...searchToolBaseFields,
       scrapeOptions: scrapeParamsSchema
-        .omit({ url: true })
+        .omit({ url: true, response_format: true })
         .partial()
         .optional(),
     })
     .refine(searchDomainsAreExclusive, SEARCH_DOMAINS_CONFLICT_MESSAGE),
   execute: async (args: unknown, { session, log }): Promise<string> => {
-    const { query, ...opts } = args as Record<string, unknown>;
+    const { query, response_format = 'detailed', ...opts } = args as Record<
+      string,
+      unknown
+    > & { response_format?: ResponseFormat };
 
     const searchOpts = { ...opts } as Record<string, unknown>;
     const includeDomains = searchOpts.includeDomains as string[] | undefined;
@@ -2112,7 +2296,11 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
       // identifier to keyless clients, where it would invite an unusable call.
       const keylessResponse = { ...(json ?? {}) };
       delete keylessResponse.id;
-      return asText(keylessResponse);
+      return formatToolResponse(
+        keylessResponse,
+        response_format,
+        'Use a lower limit, narrower query, or fewer scrapeOptions formats to retrieve omitted results.'
+      );
     }
     // Call /v2/search through the SDK's HTTP layer (auth + retries) instead
     // of `client.search()` so we preserve the full response envelope. The
@@ -2120,7 +2308,11 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
     // supports the optional authenticated `firecrawl_search_feedback` workflow.
     const client = getClient(session);
     const httpRes = await (client as any).http.post('/v2/search', searchBody);
-    return asText(httpRes?.data ?? {});
+    return formatToolResponse(
+      httpRes?.data ?? {},
+      response_format,
+      'Use a lower limit, narrower query, or fewer scrapeOptions formats to retrieve omitted results.'
+    );
   },
 });
 
@@ -2259,41 +2451,61 @@ async function keylessPost(
   return json;
 }
 
+function crawlPageData(body: any): unknown[] {
+  return Array.isArray(body.data) ? body.data : body.data?.pages || [];
+}
+
+function crawlDataBytes(docs: unknown[]): number {
+  return Buffer.byteLength(JSON.stringify(docs));
+}
+
+function validatedCrawlContinuation(jobId: string, continuation: string): string {
+  const apiBase = new URL(resolveApiBaseUrl());
+  const url = new URL(continuation, apiBase);
+  const expectedPath = `/v2/crawl/${encodeURIComponent(jobId)}`;
+  if (url.origin !== apiBase.origin || url.pathname !== expectedPath) {
+    throw new Error('Crawl continuation must belong to this crawl job.');
+  }
+  return `${url.pathname}${url.search}`;
+}
+
 async function getCrawlStatusWithOrigin(
   client: FirecrawlApp,
-  jobId: string
+  jobId: string,
+  continuation?: string
 ): Promise<Record<string, unknown>> {
-  const res = await (client as any).http.get(
-    `/v2/crawl/${encodeURIComponent(jobId)}`,
-    ORIGIN_HEADERS
-  );
+  const requestPath = continuation
+    ? validatedCrawlContinuation(jobId, continuation)
+    : `/v2/crawl/${encodeURIComponent(jobId)}`;
+  const res = await (client as any).http.get(requestPath, ORIGIN_HEADERS);
   const body = (res?.data ?? {}) as any;
-  const initialDocs = Array.isArray(body.data) ? body.data : [];
+  const docs = crawlPageData(body).slice();
+  let current =
+    body.next ??
+    (Array.isArray(body.data) ? null : body.data?.next) ??
+    null;
+  let bytes = crawlDataBytes(docs);
 
-  if (!body.next) {
-    return {
-      id: jobId,
-      status: body.status,
-      completed: body.completed ?? 0,
-      total: body.total ?? 0,
-      creditsUsed: body.creditsUsed,
-      expiresAt: body.expiresAt,
-      next: body.next ?? null,
-      data: initialDocs,
-    };
-  }
-
-  const docs = initialDocs.slice();
-  let current = body.next as string | null;
-  while (current) {
+  while (
+    current &&
+    docs.length < CRAWL_MAX_DOCUMENTS &&
+    bytes < CRAWL_MAX_BYTES
+  ) {
     const pageRes = await (client as any).http.get(current, ORIGIN_HEADERS);
     const payload = (pageRes?.data ?? {}) as any;
     if (!payload.success) break;
 
-    const pageData = Array.isArray(payload.data)
-      ? payload.data
-      : payload.data?.pages || [];
+    const pageData = crawlPageData(payload);
+    const pageBytes = crawlDataBytes(pageData);
+    if (
+      docs.length > 0 &&
+      (docs.length + pageData.length > CRAWL_MAX_DOCUMENTS ||
+        bytes + pageBytes > CRAWL_MAX_BYTES)
+    ) {
+      break;
+    }
     docs.push(...pageData);
+    bytes += pageBytes;
     current =
       payload.next ??
       (Array.isArray(payload.data) ? null : payload.data?.next) ??
@@ -2307,7 +2519,7 @@ async function getCrawlStatusWithOrigin(
     total: body.total ?? 0,
     creditsUsed: body.creditsUsed,
     expiresAt: body.expiresAt,
-    next: null,
+    next: current,
     data: docs,
   };
 }
@@ -2645,7 +2857,7 @@ server.addTool({
   description: `
 Start a multi-page crawl at a website URL, poll it to a terminal state, and return the final status and collected data. Scope can be bounded with include/exclude paths, depth, page limit, subdomain/external-link controls, sitemap handling, delay, and scrape options.
 
-Crawl results can be large; use conservative limits when full-site coverage is unnecessary. Webhooks and interactive scrape actions are unavailable in safe mode. Returns the crawl ID, status, and page data.
+Crawl results can be large; use conservative limits when full-site coverage is unnecessary. Webhooks and interactive scrape actions are unavailable in safe mode. Returns the crawl ID, status, page data, and a \`next\` continuation when more pages remain. \`response_format\` defaults to \`detailed\`.
 `,
   parameters: z.object({
     url: z.string(),
@@ -2668,10 +2880,20 @@ Crawl results can be large; use conservative limits when full-site coverage is u
         }),
     deduplicateSimilarURLs: z.boolean().optional(),
     ignoreQueryParameters: z.boolean().optional(),
-    scrapeOptions: scrapeParamsSchema.omit({ url: true }).partial().optional(),
+    scrapeOptions: scrapeParamsSchema
+      .omit({ url: true, response_format: true })
+      .partial()
+      .optional(),
+    response_format: responseFormatSchema,
   }),
   execute: async (args, { session, log }) => {
-    const { url, ...options } = args as Record<string, unknown>;
+    const {
+      url,
+      response_format = 'detailed',
+      ...options
+    } = args as Record<string, unknown> & {
+      response_format?: ResponseFormat;
+    };
     const client = getClient(session);
 
     const opts = { ...options } as Record<string, unknown>;
@@ -2705,7 +2927,11 @@ Crawl results can be large; use conservative limits when full-site coverage is u
     });
     const crawlId = started?.data?.id;
     if (!crawlId) {
-      return asText(started?.data ?? {});
+      return formatToolResponse(
+        started?.data ?? {},
+        response_format,
+        'Use a narrower crawl request to retrieve omitted response fields.'
+      );
     }
     const res = await waitForCrawlCompletionWithOrigin(
       client,
@@ -2713,7 +2939,13 @@ Crawl results can be large; use conservative limits when full-site coverage is u
       pollInterval,
       timeout
     );
-    return asText(res);
+    return formatToolResponse(
+      res,
+      response_format,
+      res.next
+        ? `Call firecrawl_check_crawl_status with id: "${crawlId}" and next: "${String(res.next)}" to retrieve later documents; narrow scrapeOptions to retrieve omitted document fields.`
+        : 'Narrow scrapeOptions to retrieve omitted document fields.'
+    );
   },
 });
 
@@ -2726,17 +2958,35 @@ server.addTool({
     destructiveHint: false, // Status lookup only; no deletes or updates.
   },
   description: `
-Retrieve the current status, progress, and available results for an existing crawl ID. This only reads Firecrawl job state and does not start or modify the crawl.
+Retrieve the current status, progress, and available results for an existing crawl ID. This only reads Firecrawl job state and does not start or modify the crawl. When \`next\` is returned, pass it with the same ID to retrieve later documents. \`response_format\` defaults to \`detailed\`.
 `,
-  parameters: z.object({ id: z.string() }),
+  parameters: z.object({
+    id: z.string(),
+    next: z.string().max(4_096).optional(),
+    response_format: responseFormatSchema,
+  }),
   execute: async (
     args: unknown,
     { session }: { session?: SessionData }
   ): Promise<string> => {
     const client = getClient(session);
-    const id = (args as any).id as string;
-    const res = await getCrawlStatusWithOrigin(client, id);
-    return asText(res);
+    const {
+      id,
+      next,
+      response_format = 'detailed',
+    } = args as {
+      id: string;
+      next?: string;
+      response_format?: ResponseFormat;
+    };
+    const res = await getCrawlStatusWithOrigin(client, id, next);
+    return formatToolResponse(
+      res,
+      response_format,
+      res.next
+        ? `Call firecrawl_check_crawl_status with id: "${id}" and next: "${String(res.next)}" to retrieve later documents; narrow the crawl request to retrieve omitted document fields.`
+        : 'Narrow the crawl request to retrieve omitted document fields.'
+    );
   },
 });
 
@@ -2823,18 +3073,28 @@ server.addTool({
   description: `
 Retrieve progress or final results for a \`firecrawl_agent\` job ID. A \`processing\` response is non-terminal and does not contain the final research result. Check again after 15–30 seconds until the status is \`completed\` or \`failed\`; complex jobs can take several minutes. If the job cannot finish within the task's available time, use \`firecrawl_search\` and \`firecrawl_scrape\` to complete the requested output.
 
-Returns job status, progress information, and result data when completed.
+Returns job status, progress information, and result data when completed. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
 `,
-  parameters: z.object({ id: z.string() }),
+  parameters: z.object({
+    id: z.string(),
+    response_format: responseFormatSchema,
+  }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
     const client = getClient(session);
-    const { id } = args as { id: string };
+    const { id, response_format = 'detailed' } = args as {
+      id: string;
+      response_format?: ResponseFormat;
+    };
     log.info('Checking agent status', { id });
     const res = await (client as any).http.get(
       `/v2/agent/${encodeURIComponent(id)}`,
       ORIGIN_HEADERS
     );
-    return asText(res?.data ?? {});
+    return formatToolResponse(
+      res?.data ?? {},
+      response_format,
+      'Use a narrower agent prompt or schema to retrieve omitted result content.'
+    );
   },
 });
 
@@ -2850,7 +3110,7 @@ server.addTool({
   description: `
 Open or reuse a live browser session to navigate a page, click controls, fill fields, or run browser code. Provide either \`url\` or \`scrapeId\`, and either a natural-language \`prompt\` or executable \`code\`; code can run as Bash, Python, or Node with a bounded timeout.
 
-This acts on the live site, so actions such as form submission can create persistent external side effects. Returns execution output, stdout/stderr, exit status, and session viewing URLs.
+This acts on the live site, so actions such as form submission can create persistent external side effects. Returns execution output, stdout/stderr, exit status, and session viewing URLs. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky output and reports omissions.
 `,
   parameters: z
     .object({
@@ -2860,7 +3120,11 @@ This acts on the live site, so actions such as form submission can create persis
       code: z.string().trim().min(1).optional(),
       language: z.enum(['bash', 'python', 'node']).optional(),
       timeout: z.number().min(1).max(300).optional(),
-      scrapeOptions: scrapeParamsSchema.omit({ url: true }).partial().optional(),
+      scrapeOptions: scrapeParamsSchema
+        .omit({ url: true, response_format: true })
+        .partial()
+        .optional(),
+      response_format: responseFormatSchema,
     })
     .refine((data) => Boolean(data.scrapeId) !== Boolean(data.url), {
       message:
@@ -2882,6 +3146,7 @@ This acts on the live site, so actions such as form submission can create persis
       language,
       timeout,
       scrapeOptions,
+      response_format = 'detailed',
     } = args as {
       scrapeId?: string;
       url?: string;
@@ -2890,6 +3155,7 @@ This acts on the live site, so actions such as form submission can create persis
       language?: 'bash' | 'python' | 'node';
       timeout?: number;
       scrapeOptions?: Record<string, unknown>;
+      response_format?: ResponseFormat;
     };
     // No scrapeId means the caller passed a url: scrape it first to open the
     // session, then interact. One tool call instead of scrape + interact.
@@ -2904,18 +3170,26 @@ This acts on the live site, so actions such as form submission can create persis
       } as any);
       scrapeId = (scraped as any)?.metadata?.scrapeId;
       if (!scrapeId) {
-        return asText({
-          error:
-            'Could not open an interact session: the scrape did not return a scrapeId. Try firecrawl_scrape first, then pass its scrapeId.',
-          url,
-        });
+        return formatToolResponse(
+          {
+            error:
+              'Could not open an interact session: the scrape did not return a scrapeId. Try firecrawl_scrape first, then pass its scrapeId.',
+            url,
+          },
+          response_format,
+          'Use a shorter URL to retrieve the complete error response.'
+        );
       }
     }
     if (!scrapeId) {
-      return asText({
-        error: 'Could not open an interact session: missing scrapeId.',
-        url,
-      });
+      return formatToolResponse(
+        {
+          error: 'Could not open an interact session: missing scrapeId.',
+          url,
+        },
+        response_format,
+        'Use a shorter URL to retrieve the complete error response.'
+      );
     }
     const activeScrapeId = scrapeId;
     log.info('Interacting with page', { scrapeId: activeScrapeId });
@@ -2926,15 +3200,27 @@ This acts on the live site, so actions such as form submission can create persis
     if (timeout != null) interactArgs.timeout = timeout;
     const res = await client.interact(activeScrapeId, interactArgs as any);
     if (openedFromUrl && res && typeof res === 'object' && !Array.isArray(res)) {
-      return asText({
-        ...(res as unknown as Record<string, unknown>),
-        scrapeId: activeScrapeId,
-      });
+      return formatToolResponse(
+        {
+          ...(res as unknown as Record<string, unknown>),
+          scrapeId: activeScrapeId,
+        },
+        response_format,
+        'Use a narrower interaction prompt or code output to retrieve omitted content.'
+      );
     }
     if (openedFromUrl) {
-      return asText({ scrapeId: activeScrapeId, result: res });
+      return formatToolResponse(
+        { scrapeId: activeScrapeId, result: res },
+        response_format,
+        'Use a narrower interaction prompt or code output to retrieve omitted content.'
+      );
     }
-    return asText(res);
+    return formatToolResponse(
+      res,
+      response_format,
+      'Use a narrower interaction prompt or code output to retrieve omitted content.'
+    );
   },
 });
 
@@ -2979,7 +3265,7 @@ Parse one supported document into markdown, HTML, links, summary, targeted answe
 
 Local MCP reads \`filePath\` from the server filesystem. Hosted MCP uses two calls: first provide \`filePath\` to receive upload instructions, upload locally, then call again with the returned \`uploadRef\`; do not send both fields together. Remote web URLs belong in \`firecrawl_scrape\`.
 
-Set \`redactPII\` to request redaction of personally identifiable information in the returned content. \`zeroDataRetention\` requires an eligible authenticated account; omit it for anonymous keyless use. Returns upload instructions for hosted phase one or parsed document content for the final call.
+Set \`redactPII\` to request redaction of personally identifiable information in the returned content. \`zeroDataRetention\` requires an eligible authenticated account; omit it for anonymous keyless use. Returns upload instructions for hosted phase one or parsed document content for the final call. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
 `,
   parameters: parseParamsSchema,
   execute: async (args: unknown, { session, log }): Promise<string> => {
@@ -2997,10 +3283,12 @@ Set \`redactPII\` to request redaction of personally identifiable information in
     const {
       filePath,
       contentType: overrideContentType,
+      response_format = 'detailed',
       ...options
     } = args as {
       filePath: string;
       contentType?: string;
+      response_format?: ResponseFormat;
     } & Record<string, unknown>;
 
     const absPath = path.resolve(filePath);
@@ -3049,9 +3337,23 @@ Set \`redactPII\` to request redaction of personally identifiable information in
     }
 
     try {
-      return asText(JSON.parse(responseText));
+      return formatToolResponse(
+        JSON.parse(responseText),
+        response_format,
+        'Parse fewer pages or request fewer output formats to retrieve omitted content.'
+      );
     } catch {
-      return responseText;
+      if (
+        response_format === 'detailed' &&
+        responseText.length <= DETAILED_RESPONSE_MAX_CHARS
+      ) {
+        return responseText;
+      }
+      return formatToolResponse(
+        responseText,
+        response_format,
+        'Parse fewer pages or request fewer output formats to retrieve omitted content.'
+      );
     }
   },
 });
@@ -3077,7 +3379,7 @@ Search web and specialized indexes, returning ranked results. Operators include 
 
 For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
 
-Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
+Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
 `,
     parameters: z
       .object({ ...searchToolBaseFields })
@@ -3099,6 +3401,7 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
         categories,
         highlights,
         enterprise,
+        response_format = 'detailed',
       } = args as {
         query: string;
         includeDomains?: string[];
@@ -3111,6 +3414,7 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
         categories?: string[];
         highlights?: boolean;
         enterprise?: string[];
+        response_format?: ResponseFormat;
       };
 
       const searchQuery = buildSearchQueryWithDomains(
@@ -3139,7 +3443,11 @@ Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`.
       log.info('Searching', { query: searchQuery });
       const client = getClientFn(session);
       const httpRes = await (client as any).http.post('/v2/search', searchBody);
-      return asText(httpRes?.data ?? {});
+      return formatToolResponse(
+        httpRes?.data ?? {},
+        response_format,
+        'Use a lower limit or narrower query to retrieve omitted results.'
+      );
     },
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1210,7 +1210,7 @@ function wrapToolError(error: unknown, requestId: string): UserError {
       true
     );
   }
-  if (/requires|must belong|provide (?:either|exactly)|missing/i.test(message)) {
+  if (/^Crawl continuation must belong to this crawl job\.$/.test(message)) {
     return agentLegibleError(
       'INVALID_REQUEST',
       error,
@@ -1258,7 +1258,7 @@ function emitActionLog(
   status: ActionStatus,
   session?: SessionData,
   error?: unknown,
-  requestId = randomUUID(),
+  requestId: string = randomUUID(),
   code?: string
 ): void {
   if (process.env.CLOUD_SERVICE !== 'true') return;
@@ -1354,18 +1354,27 @@ function guardHostedTool(
             ? payload.code
             : undefined;
         if (logActions && earlyResult.isError && recoveryCode) {
+          const recoveryRequestId =
+            payload &&
+            typeof payload === 'object' &&
+            'request_id' in payload &&
+            typeof payload.request_id === 'string'
+              ? payload.request_id
+              : randomUUID();
           emitActionLog(
             tool.name,
             'error',
             session,
             new UserError(`Tool validation failed: ${recoveryCode}`, payload),
-            randomUUID(),
+            recoveryRequestId,
             recoveryCode
           );
         }
         return earlyResult;
       }
 
+      // FastMCP validates again after this hook; validating here preserves
+      // structured issue details instead of its flattened validation error.
       const schema = tool.parameters as typeof tool.parameters & {
         safeParseAsync?: (value: unknown) => Promise<{
           success: boolean;
@@ -1609,8 +1618,11 @@ function compactResponseValue(
 ): unknown {
   if (typeof value === 'string') {
     if (value.length <= limits.stringChars) return value;
-    stats.characters += value.length - limits.stringChars;
-    return `${value.slice(0, limits.stringChars)}\n[truncated ${value.length - limits.stringChars} characters]`;
+    let retainedChars = limits.stringChars;
+    const lastCodeUnit = value.charCodeAt(retainedChars - 1);
+    if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) retainedChars -= 1;
+    stats.characters += value.length - retainedChars;
+    return `${value.slice(0, retainedChars)}\n[truncated ${value.length - retainedChars} characters]`;
   }
   if (!value || typeof value !== 'object') return value;
   if (depth >= 12) {
@@ -1671,7 +1683,13 @@ function withTruncationMetadata(
   metadata: Record<string, unknown>
 ): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
-    ? { ...(value as Record<string, unknown>), _firecrawl: metadata }
+    ? {
+        ...(value as Record<string, unknown>),
+        _firecrawl: {
+          ...(resultRecord((value as Record<string, unknown>)._firecrawl) ?? {}),
+          ...metadata,
+        },
+      }
     : { result: value, _firecrawl: metadata };
 }
 
@@ -1691,18 +1709,23 @@ function withResultNotice(
   if (!root) return data;
   const body = resultRecord(root.data) ?? root;
   const statusCode = Number(body.metadata?.statusCode ?? root.statusCode);
-  const blocked =
-    kind === 'scrape' &&
-    ([401, 403, 429].includes(statusCode) ||
-      /blocked|captcha|access denied/i.test(
-        String(body.warning ?? body.error ?? root.warning ?? root.error ?? '')
-      ));
 
   let empty = false;
+  let blocked = false;
   if (kind === 'scrape') {
     const contentFields = ['markdown', 'html', 'rawHtml', 'json', 'summary'];
+    const contentLength = contentFields.reduce(
+      (length, field) => length + JSON.stringify(body[field] ?? '').length,
+      0
+    );
     empty = contentFields.some((field) => field in body) &&
       contentFields.every((field) => body[field] == null || body[field] === '');
+    const blockingSignal =
+      [401, 403, 429].includes(statusCode) ||
+      /blocked|captcha|access denied/i.test(
+        String(body.warning ?? body.error ?? root.warning ?? root.error ?? '')
+      );
+    blocked = blockingSignal && (empty || contentLength <= 200);
   } else if (kind === 'search') {
     const groups = Object.values(resultRecord(root.data) ?? {}).filter(Array.isArray);
     empty = groups.length > 0 && groups.every((group) => group.length === 0);
@@ -1778,14 +1801,18 @@ function formatToolResponse(
     );
     const hadOmissions =
       stats.arrayItems > 0 || stats.characters > 0 || stats.fields > 0;
-    if (!hadOmissions) return asText(compacted);
-    const output = asText(
-      withTruncationMetadata(
-        compacted,
-        truncationMetadata(format, stats, guidance)
-      )
-    );
-    if (output.length <= maxChars) return output;
+    if (!hadOmissions) {
+      const output = asText(compacted);
+      if (output.length <= maxChars) return output;
+    } else {
+      const output = asText(
+        withTruncationMetadata(
+          compacted,
+          truncationMetadata(format, stats, guidance)
+        )
+      );
+      if (output.length <= maxChars) return output;
+    }
     if (
       limits.arrayItems === 1 &&
       limits.objectFields === 1 &&
@@ -2828,11 +2855,12 @@ function crawlDataBytes(docs: unknown[]): number {
 function validatedCrawlContinuation(jobId: string, continuation: string): string {
   const apiBase = new URL(resolveApiBaseUrl());
   const url = new URL(continuation, apiBase);
-  const expectedPath = `/v2/crawl/${encodeURIComponent(jobId)}`;
+  const apiBasePath = apiBase.pathname.replace(/\/$/, '');
+  const expectedPath = `${apiBasePath}/v2/crawl/${encodeURIComponent(jobId)}`;
   if (url.origin !== apiBase.origin || url.pathname !== expectedPath) {
     throw new Error('Crawl continuation must belong to this crawl job.');
   }
-  return `${url.pathname}${url.search}`;
+  return `${url.pathname.slice(apiBasePath.length)}${url.search}`;
 }
 
 async function getCrawlStatusWithOrigin(
@@ -3437,7 +3465,7 @@ server.addTool({
 Retrieve status and available results for an existing crawl ID without starting or modifying it. Pass a returned \`next\` value with the same ID to retrieve later documents.
 `,
   parameters: z.object({
-    id: z.string().describe('Crawl job ID.'),
+    id: z.string().min(1).describe('Crawl job ID.'),
     next: z
       .string()
       .max(4_096)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1191,7 +1191,7 @@ function wrapToolError(error: unknown, requestId: string): UserError {
     return agentLegibleError(
       'AUTH_REQUIRED',
       error,
-      'Configure a Firecrawl API key, connect the existing Firecrawl MCP server, or set FIRECRAWL_API_URL for a self-hosted instance, then start a new session and retry.',
+      'If other Firecrawl tools succeed, this failure may be limited to this operation: retry once or accomplish the step with another Firecrawl tool such as firecrawl_scrape. Otherwise configure a Firecrawl API key or set FIRECRAWL_API_URL for a self-hosted instance, then start a new session and retry.',
       requestId
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1176,7 +1176,20 @@ class InvalidCrawlContinuationError extends Error {
   }
 }
 
-function wrapToolError(error: unknown, requestId: string): UserError {
+// Tools whose failed calls may already have produced external side effects (a
+// submitted form, a created monitor). Unclassified failures on these must not
+// advertise retryable: an obedient agent would repeat the side effect.
+const NON_IDEMPOTENT_TOOLS = new Set([
+  'firecrawl_interact',
+  'firecrawl_monitor_create',
+]);
+
+function wrapToolError(
+  error: unknown,
+  requestId: string,
+  toolName?: string
+): UserError {
+  const safeToRepeat = !NON_IDEMPOTENT_TOOLS.has(toolName ?? '');
   if (error instanceof UserError) return error;
   const message = errorText(error);
   if (/unauthori[sz]ed|api key|credentials? required/i.test(message)) {
@@ -1207,9 +1220,11 @@ function wrapToolError(error: unknown, requestId: string): UserError {
     return agentLegibleError(
       'UPSTREAM_TIMEOUT',
       error,
-      'Retry once with a narrower request or a longer supported timeout; if the job ID is known, check its status instead of starting a duplicate job.',
+      safeToRepeat
+        ? 'Retry once with a narrower request or a longer supported timeout; if the job ID is known, check its status instead of starting a duplicate job.'
+        : 'The action may have taken effect despite the timeout. Verify the current state (re-check the page or list existing monitors) before repeating it.',
       requestId,
-      true
+      safeToRepeat
     );
   }
   if (error instanceof InvalidCrawlContinuationError) {
@@ -1223,9 +1238,11 @@ function wrapToolError(error: unknown, requestId: string): UserError {
   return agentLegibleError(
     'UPSTREAM_REQUEST_FAILED',
     error,
-    'Verify the request and Firecrawl service availability, then retry once if the operation is safe to repeat.',
+    safeToRepeat
+      ? 'Verify the request and Firecrawl service availability, then retry once if the operation is safe to repeat.'
+      : 'The action may have taken effect despite the error. Verify the current state (re-check the page or list existing monitors) before repeating it.',
     requestId,
-    true
+    safeToRepeat
   );
 }
 
@@ -1455,7 +1472,7 @@ function guardHostedTool(
         }
         return result;
       } catch (error) {
-        const wrapped = wrapToolError(error, requestId);
+        const wrapped = wrapToolError(error, requestId, tool.name);
         if (logActions) {
           emitActionLog(
             tool.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -806,13 +806,6 @@ function buildSearchQueryWithDomains(
   return query;
 }
 
-type ResponseFormat = 'concise' | 'detailed';
-
-const responseFormatSchema = z
-  .enum(['concise', 'detailed'])
-  .default('detailed')
-  .describe('Response detail level; defaults to detailed.');
-
 // Parameter fields shared by both firecrawl_search surfaces. The full surface
 // adds `scrapeOptions` on top; the search surface uses these as-is (strict, no
 // scrapeOptions). Defining the field set once keeps the two surfaces from
@@ -857,7 +850,6 @@ const searchToolBaseFields = {
     .array(z.enum(['default', 'anon', 'zdr']))
     .optional()
     .describe('Enterprise search modes when enabled for the account.'),
-  response_format: responseFormatSchema,
 };
 
 // Both surfaces forbid specifying includeDomains and excludeDomains together.
@@ -1610,20 +1602,16 @@ type TruncationStats = {
   fields: number;
 };
 
-// Detailed stays compatible for ordinary payloads; both ceilings prevent one
-// tool result from consuming an agent's context window (~3k/~16k tokens).
-const CONCISE_RESPONSE_MAX_CHARS = 12_000;
-const DETAILED_RESPONSE_MAX_CHARS = 64_000;
+// Ordinary payloads stay unchanged; the ceiling prevents one tool result from
+// consuming an agent's context window (~16k tokens).
+const RESPONSE_MAX_CHARS = 64_000;
 const CRAWL_MAX_DOCUMENTS = 25;
 const CRAWL_MAX_BYTES = 48_000;
-
-const conciseOmittedFields = /(?:base64|screenshot)/i;
 
 function compactResponseValue(
   value: unknown,
   limits: { arrayItems: number; objectFields: number; stringChars: number },
   stats: TruncationStats,
-  concise: boolean,
   depth = 0
 ): unknown {
   if (typeof value === 'string') {
@@ -1643,31 +1631,22 @@ function compactResponseValue(
     const retained = value.slice(0, limits.arrayItems);
     stats.arrayItems += value.length - retained.length;
     return retained.map((item) =>
-      compactResponseValue(item, limits, stats, concise, depth + 1)
+      compactResponseValue(item, limits, stats, depth + 1)
     );
   }
 
-  const record = value as Record<string, unknown>;
-  const hasMarkdown = typeof record.markdown === 'string' && record.markdown.length > 0;
-  const entries = Object.entries(record).filter(([key]) => {
-    const omit =
-      concise &&
-      (conciseOmittedFields.test(key) || (key === 'rawHtml' && hasMarkdown));
-    if (omit) stats.fields += 1;
-    return !omit;
-  });
+  const entries = Object.entries(value as Record<string, unknown>);
   const retained = entries.slice(0, limits.objectFields);
   stats.fields += entries.length - retained.length;
   return Object.fromEntries(
     retained.map(([key, item]) => [
       key,
-      compactResponseValue(item, limits, stats, concise, depth + 1),
+      compactResponseValue(item, limits, stats, depth + 1),
     ])
   );
 }
 
 function truncationMetadata(
-  format: ResponseFormat,
   stats: TruncationStats,
   guidance: string
 ): Record<string, unknown> {
@@ -1676,15 +1655,10 @@ function truncationMetadata(
     array_items: stats.arrayItems,
     characters: stats.characters,
   };
-  const detailGuidance =
-    format === 'concise'
-      ? 'Use response_format: "detailed" to include fields omitted by concise format. '
-      : '';
   return {
     truncated: true,
-    response_format: format,
     omitted,
-    message: `Response truncated; omitted ${omitted.fields} fields, ${omitted.array_items} array items, and ${omitted.characters} characters. ${detailGuidance}${guidance.slice(0, 2_000)}`.trim(),
+    message: `Response truncated; omitted ${omitted.fields} fields, ${omitted.array_items} array items, and ${omitted.characters} characters. ${guidance.slice(0, 2_000)}`.trim(),
   };
 }
 
@@ -1801,45 +1775,24 @@ function withResultNotice(
   };
 }
 
-function formatToolResponse(
-  data: unknown,
-  format: ResponseFormat,
-  guidance: string
-): string {
-  const maxChars =
-    format === 'concise'
-      ? CONCISE_RESPONSE_MAX_CHARS
-      : DETAILED_RESPONSE_MAX_CHARS;
-  if (format === 'detailed') {
-    const unchanged = asText(data);
-    if (unchanged.length <= maxChars) return unchanged;
-  }
+function formatToolResponse(data: unknown, guidance: string): string {
+  const unchanged = asText(data);
+  if (unchanged.length <= RESPONSE_MAX_CHARS) return unchanged;
 
-  let limits =
-    format === 'concise'
-      ? { arrayItems: 8, objectFields: 30, stringChars: 2_000 }
-      : { arrayItems: 50, objectFields: 100, stringChars: 12_000 };
+  let limits = { arrayItems: 50, objectFields: 100, stringChars: 12_000 };
   for (;;) {
     const stats: TruncationStats = { arrayItems: 0, characters: 0, fields: 0 };
-    const compacted = compactResponseValue(
-      data,
-      limits,
-      stats,
-      format === 'concise'
-    );
+    const compacted = compactResponseValue(data, limits, stats);
     const hadOmissions =
       stats.arrayItems > 0 || stats.characters > 0 || stats.fields > 0;
     if (!hadOmissions) {
       const output = asText(compacted);
-      if (output.length <= maxChars) return output;
+      if (output.length <= RESPONSE_MAX_CHARS) return output;
     } else {
       const output = asText(
-        withTruncationMetadata(
-          compacted,
-          truncationMetadata(format, stats, guidance)
-        )
+        withTruncationMetadata(compacted, truncationMetadata(stats, guidance))
       );
-      if (output.length <= maxChars) return output;
+      if (output.length <= RESPONSE_MAX_CHARS) return output;
     }
     if (
       limits.arrayItems === 1 &&
@@ -1847,7 +1800,7 @@ function formatToolResponse(
       limits.stringChars === 128
     ) {
       return asText({
-        _firecrawl: truncationMetadata(format, stats, guidance),
+        _firecrawl: truncationMetadata(stats, guidance),
       });
     }
     limits = {
@@ -1935,8 +1888,6 @@ function transformScrapeParams(
   args: Record<string, unknown>
 ): Record<string, unknown> {
   const out = { ...args };
-  delete out.response_format;
-
   const formats = buildFormatsArray(out);
   if (formats) out.formats = formats;
 
@@ -2109,7 +2060,6 @@ const scrapeParamsSchema = z.object({
     })
     .optional()
     .describe('Reusable browser profile configuration.'),
-  response_format: responseFormatSchema,
 });
 
 const parseOptionParamsSchema = z.object({
@@ -2200,7 +2150,6 @@ const parseOptionParamsSchema = z.object({
     .enum(['basic', 'auto'])
     .optional()
     .describe('Proxy mode used for remote document URLs.'),
-  response_format: responseFormatSchema,
 });
 
 const localParseParamsSchema = parseOptionParamsSchema.extend({
@@ -2301,7 +2250,6 @@ function extractParseOptions(args: ParseToolArgs): Record<string, unknown> {
   delete options.uploadRef;
   delete options.contentType;
   delete options.declaredSizeBytes;
-  delete options.response_format;
   return options;
 }
 
@@ -2441,7 +2389,6 @@ async function executeHostedParse(
     throw new UserError(String(payload.message), payload);
   }
 
-  const responseFormat = args.response_format ?? 'detailed';
   const options = extractParseOptions(args);
 
   if (args.filePath) {
@@ -2497,7 +2444,6 @@ async function executeHostedParse(
         arguments: {
           uploadRef: upload.uploadRef,
           ...(removeEmptyTopLevel(options) as Record<string, unknown>),
-          response_format: responseFormat,
         },
       },
         notes: [
@@ -2506,7 +2452,6 @@ async function executeHostedParse(
           'Clients without a local upload mechanism cannot complete hosted parse for local files.',
         ],
       },
-      responseFormat,
       'Use a shorter file path and fewer parse options to retrieve omitted upload instructions.'
     );
   }
@@ -2523,7 +2468,6 @@ async function executeHostedParse(
   );
   return formatToolResponse(
     parseJson,
-    responseFormat,
     'Parse fewer pages or request fewer output formats to retrieve the omitted content.'
   );
 }
@@ -2541,9 +2485,7 @@ Retrieve content or structured fields from one supplied URL. Use this when the r
 `,
   parameters: scrapeParamsSchema,
   execute: async (args: unknown, { session, log }): Promise<string> => {
-    const { url, response_format = 'detailed', ...options } = args as z.infer<
-      typeof scrapeParamsSchema
-    >;
+    const { url, ...options } = args as z.infer<typeof scrapeParamsSchema>;
     const transformed = transformScrapeParams(options);
     const cleaned = removeEmptyTopLevel(transformed);
     if (cleaned.lockdown) {
@@ -2563,7 +2505,6 @@ Retrieve content or structured fields from one supplied URL. Use this when the r
       );
       return formatToolResponse(
         withResultNotice(json?.data ?? json, 'scrape'),
-        response_format,
         'Request fewer formats or narrow the extraction to retrieve omitted page content.'
       );
     }
@@ -2574,7 +2515,6 @@ Retrieve content or structured fields from one supplied URL. Use this when the r
     } as any);
     return formatToolResponse(
       withResultNotice(res, 'scrape'),
-      response_format,
       'Request fewer formats or narrow the extraction to retrieve omitted page content.'
     );
   },
@@ -2622,7 +2562,6 @@ Enumerate URLs under one website without fetching each page. Returns matching UR
     } as any);
     return formatToolResponse(
       withResultNotice(res, 'map'),
-      'detailed',
       'Retry firecrawl_map with a lower limit or narrower search term to retrieve omitted URLs.'
     );
   },
@@ -2645,7 +2584,7 @@ Search web, news, image, and specialized sources. Operators include quoted phras
     .object({
       ...searchToolBaseFields,
       scrapeOptions: scrapeParamsSchema
-        .omit({ url: true, response_format: true })
+        .omit({ url: true })
         .partial()
         .optional()
         .describe(
@@ -2654,10 +2593,7 @@ Search web, news, image, and specialized sources. Operators include quoted phras
     })
     .refine(searchDomainsAreExclusive, SEARCH_DOMAINS_CONFLICT_MESSAGE),
   execute: async (args: unknown, { session, log }): Promise<string> => {
-    const { query, response_format = 'detailed', ...opts } = args as Record<
-      string,
-      unknown
-    > & { response_format?: ResponseFormat };
+    const { query, ...opts } = args as Record<string, unknown>;
 
     const searchOpts = { ...opts } as Record<string, unknown>;
     const includeDomains = searchOpts.includeDomains as string[] | undefined;
@@ -2691,7 +2627,6 @@ Search web, news, image, and specialized sources. Operators include quoted phras
       delete keylessResponse.id;
       return formatToolResponse(
         withResultNotice(keylessResponse, 'search'),
-        response_format,
         'Use a lower limit, narrower query, or fewer scrapeOptions formats to retrieve omitted results.'
       );
     }
@@ -2703,7 +2638,6 @@ Search web, news, image, and specialized sources. Operators include quoted phras
     const httpRes = await (client as any).http.post('/v2/search', searchBody);
     return formatToolResponse(
       withResultNotice(httpRes?.data ?? {}, 'search'),
-      response_format,
       'Use a lower limit, narrower query, or fewer scrapeOptions formats to retrieve omitted results.'
     );
   },
@@ -3495,22 +3429,15 @@ Start a multi-page website crawl and wait for its terminal state. Use for page c
       .optional()
       .describe('Deduplicate URLs that differ only by query parameters.'),
     scrapeOptions: scrapeParamsSchema
-      .omit({ url: true, response_format: true })
+      .omit({ url: true })
       .partial()
       .optional()
       .describe(
         'Scrape configuration applied to every crawled page. Rich formats increase response size and credit use.'
       ),
-    response_format: responseFormatSchema,
   }),
   execute: async (args, { session, log }) => {
-    const {
-      url,
-      response_format = 'detailed',
-      ...options
-    } = args as Record<string, unknown> & {
-      response_format?: ResponseFormat;
-    };
+    const { url, ...options } = args as Record<string, unknown>;
     const client = getClient(session);
 
     const opts = { ...options } as Record<string, unknown>;
@@ -3560,7 +3487,6 @@ Start a multi-page website crawl and wait for its terminal state. Use for page c
     );
     return formatToolResponse(
       withResultNotice(res, 'crawl'),
-      response_format,
       crawlResponseGuidance(
         res,
         crawlId,
@@ -3598,28 +3524,20 @@ Retrieve status and available results for an existing crawl ID without starting 
       .describe(
         'Zero-based document offset returned in prior guidance, applied within the page being retrieved.'
       ),
-    response_format: responseFormatSchema,
   }),
   execute: async (
     args: unknown,
     { session }: { session?: SessionData }
   ): Promise<string> => {
     const client = getClient(session);
-    const {
-      id,
-      next,
-      offset = 0,
-      response_format = 'detailed',
-    } = args as {
+    const { id, next, offset = 0 } = args as {
       id: string;
       next?: string;
       offset?: number;
-      response_format?: ResponseFormat;
     };
     const res = await getCrawlStatusWithOrigin(client, id, next, offset);
     return formatToolResponse(
       withResultNotice(res, 'crawl'),
-      response_format,
       crawlResponseGuidance(
         res,
         id,
@@ -3724,14 +3642,10 @@ Retrieve progress or final results for a \`firecrawl_agent\` job ID. A \`process
 `,
   parameters: z.object({
     id: z.string().describe('Agent job ID.'),
-    response_format: responseFormatSchema,
   }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
     const client = getClient(session);
-    const { id, response_format = 'detailed' } = args as {
-      id: string;
-      response_format?: ResponseFormat;
-    };
+    const { id } = args as { id: string };
     log.info('Checking agent status', { id });
     const res = await (client as any).http.get(
       `/v2/agent/${encodeURIComponent(id)}`,
@@ -3739,7 +3653,6 @@ Retrieve progress or final results for a \`firecrawl_agent\` job ID. A \`process
     );
     return formatToolResponse(
       withResultNotice(res?.data ?? {}, 'agent'),
-      response_format,
       'Use a narrower agent prompt or schema to retrieve omitted result content.'
     );
   },
@@ -3794,11 +3707,10 @@ Open or reuse a live browser session to interact with a page by prompt or code. 
         .optional()
         .describe('Execution timeout in seconds; maximum 300.'),
       scrapeOptions: scrapeParamsSchema
-        .omit({ url: true, response_format: true })
+        .omit({ url: true })
         .partial()
         .optional()
         .describe('Scrape configuration used only when opening url.'),
-      response_format: responseFormatSchema,
     })
     .refine((data) => Boolean(data.scrapeId) !== Boolean(data.url), {
       message:
@@ -3820,7 +3732,6 @@ Open or reuse a live browser session to interact with a page by prompt or code. 
       language,
       timeout,
       scrapeOptions,
-      response_format = 'detailed',
     } = args as {
       scrapeId?: string;
       url?: string;
@@ -3829,7 +3740,6 @@ Open or reuse a live browser session to interact with a page by prompt or code. 
       language?: 'bash' | 'python' | 'node';
       timeout?: number;
       scrapeOptions?: Record<string, unknown>;
-      response_format?: ResponseFormat;
     };
     // No scrapeId means the caller passed a url: scrape it first to open the
     // session, then interact. One tool call instead of scrape + interact.
@@ -3868,7 +3778,6 @@ Open or reuse a live browser session to interact with a page by prompt or code. 
           : res;
     return formatToolResponse(
       result,
-      response_format,
       'Use a narrower interaction prompt or code output to retrieve omitted content.'
     );
   },
@@ -3932,7 +3841,6 @@ Parse one local or uploaded document into text or structured data; remote web UR
     const {
       filePath,
       contentType: overrideContentType,
-      response_format = 'detailed',
       ...options
     } = args as z.infer<typeof localParseParamsSchema>;
 
@@ -3988,19 +3896,12 @@ Parse one local or uploaded document into text or structured data; remote web UR
     try {
       return formatToolResponse(
         JSON.parse(responseText),
-        response_format,
         'Parse fewer pages or request fewer output formats to retrieve omitted content.'
       );
     } catch {
-      if (
-        response_format === 'detailed' &&
-        responseText.length <= DETAILED_RESPONSE_MAX_CHARS
-      ) {
-        return responseText;
-      }
+      if (responseText.length <= RESPONSE_MAX_CHARS) return responseText;
       return formatToolResponse(
         responseText,
-        response_format,
         'Parse fewer pages or request fewer output formats to retrieve omitted content.'
       );
     }
@@ -4048,7 +3949,6 @@ Search web and specialized indexes. Operators include quoted phrases, \`-term\`,
         categories,
         highlights,
         enterprise,
-        response_format = 'detailed',
       } = args as {
         query: string;
         includeDomains?: string[];
@@ -4061,7 +3961,6 @@ Search web and specialized indexes. Operators include quoted phrases, \`-term\`,
         categories?: string[];
         highlights?: boolean;
         enterprise?: string[];
-        response_format?: ResponseFormat;
       };
 
       const searchQuery = buildSearchQueryWithDomains(
@@ -4092,7 +3991,6 @@ Search web and specialized indexes. Operators include quoted phrases, \`-term\`,
       const httpRes = await (client as any).http.post('/v2/search', searchBody);
       return formatToolResponse(
         withResultNotice(httpRes?.data ?? {}, 'search'),
-        response_format,
         'Use a lower limit or narrower query to retrieve omitted results.'
       );
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2507,13 +2507,7 @@ server.addTool({
     destructiveHint: false, // Does not modify, delete, or write to external websites.
   },
   description: `
-Retrieve and extract content from one supplied URL through Firecrawl. Use this when the request identifies a page and needs its content or defined fields. It can return markdown, HTML, links, screenshots, branding data, a targeted answer, or JSON matching a supplied schema; JSON is useful when the requested result has defined fields, while markdown preserves readable page content.
-
-This tool operates on a known page. For a set of pages use \`firecrawl_crawl\`, and to discover page URLs use \`firecrawl_map\` or \`firecrawl_search\`. Options include JavaScript render delay, cache age, main-content filtering, PII redaction, and lockdown cache-only retrieval. Browser actions may change the live page when interactive actions are enabled.
-
-Firecrawl may reuse recently indexed content instead of refetching the page, and the reuse window varies by domain. Set \`maxAge: 0\` to force a live fetch, or a smaller \`maxAge\` to bound how stale reused content may be. A successful response does not by itself confirm that the state it describes is still current.
-
-Returns the selected content formats and page metadata. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate formats, while both formats bound oversized responses and report omissions in-band.
+Retrieve content or structured fields from one supplied URL. Use this when the request identifies a page and needs its content or defined fields. For multiple pages use \`firecrawl_crawl\`; to discover URLs use \`firecrawl_map\` or \`firecrawl_search\`.
 `,
   parameters: scrapeParamsSchema,
   execute: async (args: unknown, { session, log }): Promise<string> => {
@@ -2568,9 +2562,7 @@ server.addTool({
     destructiveHint: false, // Read-only discovery; no deletion or destructive updates.
   },
   description: `
-Enumerate URLs indexed under one website through Firecrawl without fetching each page's content. Use this when the request asks for a site's URL inventory, when several relevant pages must be located, or when the desired page URL is unknown. An optional \`search\` term narrows the URL list, while sitemap, subdomain, query-parameter, and result-limit options control coverage.
-
-Returns matching URLs rather than page bodies. Retrieve one page with \`firecrawl_scrape\`; collect content across multiple pages with \`firecrawl_crawl\`.
+Enumerate URLs under one website without fetching each page. Returns matching URLs rather than page bodies; retrieve one page with \`firecrawl_scrape\` or multiple pages with \`firecrawl_crawl\`.
 `,
   parameters: z.object({
     url: z.string().url().describe('Website root URL to map.'),
@@ -2618,13 +2610,9 @@ server.addTool({
     destructiveHint: false, // Query-only; no destructive side effects on external entities.
   },
   description: `
-Search web, news, or image sources and return ranked results. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. \`includeDomains\` and \`excludeDomains\` are mutually exclusive hostname filters; categories limit results to GitHub, research, PDF, or developer sources.
+Search web, news, image, and specialized sources. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. Use \`categories: ["developer"]\` for indexed GitHub and documentation results.
 
-For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
-
-\`categories: ["research"]\` restricts these web results to research-affiliated websites and returns page snippets. The \`firecrawl_research_*\` tools are a separate surface that searches paper abstracts and full text across biomedical (PubMed, bioRxiv, medRxiv) and arXiv literature.
-
-\`scrapeOptions\` can attach extracted page content; pages fetched this way use a fixed reuse window and ignore \`maxAge\`, so use \`firecrawl_scrape\` when a live fetch is required. Returns source-type result groups and usage metadata. Authenticated responses can include an \`id\` for optional search feedback. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
+\`categories: ["research"]\` restricts these web results to research-affiliated websites. The \`firecrawl_research_*\` tools are a separate surface for paper abstracts and full text across biomedical (PubMed, bioRxiv, medRxiv) and arXiv literature. Authenticated responses can include an \`id\` for optional search feedback.
 `,
   parameters: z
     .object({
@@ -2991,9 +2979,7 @@ if (!SEARCH_FEEDBACK_DISABLED && !isLocalKeylessStartup()) {
       destructiveHint: false, // Additive only; records feedback and may refund credits, does not delete data.
     },
     description: `
-Records schema-validated quality feedback for a prior \`firecrawl_search\` UUID \`searchId\`. A \`good\` rating requires a valuable source, \`partial\` a valuable source or at least one \`missingContent\` entry, and \`bad\` at least one \`missingContent\` entry or a query suggestion; caps are 50 \`valuableSources\` and 20 \`missingContent\` entries.
-
-Eligibility is limited to successful searches within the feedback age window. The record is idempotent per search ID. Eligible first feedback for a search can refund 1 credit; refunds are subject to the team's daily cap. The response reports whether a refund was applied, along with submission and daily-cap status.
+Record quality feedback for a prior search ID. A \`good\` rating requires a valuable source, \`partial\` a valuable source or \`missingContent\`, and \`bad\` \`missingContent\` or a query suggestion. Caps are 50 \`valuableSources\` and 20 \`missingContent\` entries; eligible searches must be within the feedback age window, and records are idempotent per search ID. Eligible first feedback can refund 1 credit subject to the team's daily cap; the response reports whether a refund was applied and daily-cap status.
 `,
     parameters: z.object({
       searchId: z
@@ -3148,9 +3134,7 @@ if (!ENDPOINT_FEEDBACK_DISABLED && !isLocalKeylessStartup()) {
       destructiveHint: false, // Additive only; submits ratings and notes, does not delete jobs or external content.
     },
     description: `
-Submit concise quality feedback for a completed search, scrape, parse, or map job. Provide the endpoint, job ID, rating, and relevant issue codes or small contextual fields; omit large page contents and raw outputs.
-
-Returns submission status, feedback ID, and accounting fields.
+Record quality feedback for a completed search, scrape, parse, or map job. This creates feedback metadata but does not modify the original job or its result.
 `,
     parameters: z.object({
       endpoint: z
@@ -3311,9 +3295,7 @@ server.addTool({
     destructiveHint: false, // Reads pages from target sites; does not delete or alter external websites.
   },
   description: `
-Start a multi-page crawl at a website URL, poll it to a terminal state, and return the final status and collected data. Scope can be bounded with include/exclude paths, depth, page limit, subdomain/external-link controls, sitemap handling, delay, and scrape options.
-
-Crawl results can be large; use conservative limits when full-site coverage is unnecessary. Webhooks and interactive scrape actions are unavailable in safe mode. Returns the crawl ID, status, page data, and a \`next\` continuation when more pages remain. \`response_format\` defaults to \`detailed\`.
+Start a multi-page website crawl and wait for its terminal state. Use for page content across a site; \`firecrawl_map\` returns only URLs. A returned \`next\` value continues results through \`firecrawl_check_crawl_status\`.
 `,
   parameters: z.object({
     url: z.string().describe('Website URL where the crawl starts.'),
@@ -3452,7 +3434,7 @@ server.addTool({
     destructiveHint: false, // Status lookup only; no deletes or updates.
   },
   description: `
-Retrieve the current status, progress, and available results for an existing crawl ID. This only reads Firecrawl job state and does not start or modify the crawl. When \`next\` is returned, pass it with the same ID to retrieve later documents. \`response_format\` defaults to \`detailed\`.
+Retrieve status and available results for an existing crawl ID without starting or modifying it. Pass a returned \`next\` value with the same ID to retrieve later documents.
 `,
   parameters: z.object({
     id: z.string().describe('Crawl job ID.'),
@@ -3531,9 +3513,7 @@ server.addTool({
     destructiveHint: false, // Gathers information only; does not delete external data or user resources.
   },
   description: `
-Start an asynchronous web research job from a prompt, optional seed URLs, and an optional JSON schema. Use this for a requested synthesis across multiple sources when the task can wait for asynchronous completion. The agent can search, navigate, read pages, and assemble a structured result.
-
-This call returns only a job ID, not the research result. Read the job with \`firecrawl_agent_status\` until it reaches \`completed\` or \`failed\`; research commonly takes several minutes. If the job cannot finish within the task's available time, \`firecrawl_search\` and \`firecrawl_scrape\` can gather evidence synchronously.
+Start an asynchronous multi-source web research job. Use for synthesis that can wait for asynchronous completion; \`firecrawl_search\` and \`firecrawl_scrape\` return evidence synchronously. This call returns only a job ID, not the research result; read it with \`firecrawl_agent_status\`.
 `,
   parameters: z.object({
     prompt: z
@@ -3581,9 +3561,7 @@ server.addTool({
     destructiveHint: false, // Read-only status check.
   },
   description: `
-Retrieve progress or final results for a \`firecrawl_agent\` job ID. A \`processing\` response is non-terminal and does not contain the final research result. Check again after 15–30 seconds until the status is \`completed\` or \`failed\`; complex jobs can take several minutes. If the job cannot finish within the task's available time, use \`firecrawl_search\` and \`firecrawl_scrape\` to complete the requested output.
-
-Returns job status, progress information, and result data when completed. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
+Retrieve progress or final results for a \`firecrawl_agent\` job ID. A \`processing\` response is non-terminal and does not contain the final research result; check again until \`completed\` or \`failed\`.
 `,
   parameters: z.object({
     id: z.string().describe('Agent job ID.'),
@@ -3618,9 +3596,7 @@ server.addTool({
     destructiveHint: false, // Transient page interactions only; does not delete monitors, jobs, or external sites.
   },
   description: `
-Open or reuse a live browser session to navigate a page, click controls, fill fields, or run browser code. Provide either \`url\` or \`scrapeId\`, and either a natural-language \`prompt\` or executable \`code\`; code can run as Bash, Python, or Node with a bounded timeout.
-
-This acts on the live site, so actions such as form submission can create persistent external side effects. Returns execution output, stdout/stderr, exit status, and session viewing URLs. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky output and reports omissions.
+Open or reuse a live browser session to interact with a page by prompt or code. This acts on the live site, so form submissions and similar actions can create persistent external side effects.
 `,
   parameters: z
     .object({
@@ -3767,7 +3743,7 @@ server.addTool({
     destructiveHint: true, // Terminates the live browser session; this end state cannot be resumed.
   },
   description: `
-Stop the live interact session associated with a \`scrapeId\` and release its resources. Returns a success confirmation.
+Stop a live interact session and release its resources. The stopped session cannot be resumed.
 `,
   parameters: z.object({
     scrapeId: z.string().describe('Interact session ID to stop.'),
@@ -3795,11 +3771,7 @@ server.addTool({
     destructiveHint: false, // Read-only parsing; no deletion or writes to the source file.
   },
   description: `
-Parse one supported document into markdown, HTML, links, summary, targeted answers, or JSON matching a schema. Supported inputs include common HTML, PDF, Word, RTF, OpenDocument, and spreadsheet files; PDF parsing can be bounded with \`pdfOptions.maxPages\`.
-
-Local MCP reads \`filePath\` from the server filesystem. Hosted MCP uses two calls: first provide \`filePath\` to receive upload instructions, upload locally, then call again with the returned \`uploadRef\`; do not send both fields together. Remote web URLs belong in \`firecrawl_scrape\`.
-
-Set \`redactPII\` to request redaction of personally identifiable information in the returned content. \`zeroDataRetention\` requires an eligible authenticated account; omit it for anonymous keyless use. Returns upload instructions for hosted phase one or parsed document content for the final call. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
+Parse one local or uploaded document into text or structured data; remote web URLs belong in \`firecrawl_scrape\`. Local MCP reads \`filePath\`; hosted MCP first returns upload instructions, then parses the returned \`uploadRef\`. \`redactPII\` requests personal-data redaction; \`zeroDataRetention\` requires an eligible account, so omit it for anonymous keyless use.
 `,
   parameters: parseParamsSchema,
   execute: async (args: unknown, { session, log }): Promise<string> => {
@@ -3916,11 +3888,9 @@ function registerMarketplaceSearchTool(
       destructiveHint: false,
     },
     description: `
-Search web and specialized indexes, returning ranked results. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. \`includeDomains\` and \`excludeDomains\` are mutually exclusive hostname filters; categories limit result types to \`github\`, \`research\`, \`pdf\`, or \`developer\`.
+Search web and specialized indexes. Operators include quoted phrases, \`-term\`, \`site:host\`, \`inurl:term\`, \`intitle:term\`, and \`related:host\`; the set is non-exhaustive. Use \`categories: ["developer"]\` for indexed GitHub and documentation results.
 
-For a programming question, add \`categories: ["developer"]\`. It searches an index of GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, and returns the hits in \`data.developer\` beside the web results.
-
-Returns \`{ success, data, id, creditsUsed }\`, with source arrays in \`data\`. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
+\`categories: ["research"]\` restricts these web results to research-affiliated websites. The \`firecrawl_research_*\` tools are a separate surface for paper abstracts and full text across biomedical (PubMed, bioRxiv, medRxiv) and arXiv literature.
 `,
     parameters: z
       .object({ ...searchToolBaseFields })

--- a/src/index.ts
+++ b/src/index.ts
@@ -811,36 +811,53 @@ type ResponseFormat = 'concise' | 'detailed';
 
 const responseFormatSchema = z
   .enum(['concise', 'detailed'])
-  .default('detailed');
+  .default('detailed')
+  .describe('Response detail level; defaults to detailed.');
 
 // Parameter fields shared by both firecrawl_search surfaces. The full surface
 // adds `scrapeOptions` on top; the search surface uses these as-is (strict, no
 // scrapeOptions). Defining the field set once keeps the two surfaces from
 // drifting when a source type, category, or filter changes.
 const searchToolBaseFields = {
-  query: z.string().min(1),
+  query: z.string().min(1).describe('Search query, including supported search operators.'),
   highlights: z
     .boolean()
     .optional()
     .describe(
       'Return query-relevant highlights for each search result. Set to false to keep the original search snippets.'
     ),
-  limit: z.number().optional(),
-  tbs: z.string().optional(),
-  filter: z.string().optional(),
-  location: z.string().optional(),
-  includeDomains: z.array(searchDomainSchema).optional(),
-  excludeDomains: z.array(searchDomainSchema).optional(),
+  limit: z.number().optional().describe('Maximum number of results.'),
+  tbs: z.string().optional().describe('Google-style time-based search filter.'),
+  filter: z.string().optional().describe('Additional provider-specific result filter.'),
+  location: z.string().optional().describe('Geographic location for localized results.'),
+  includeDomains: z
+    .array(searchDomainSchema)
+    .optional()
+    .describe('Only return results from these hostnames.'),
+  excludeDomains: z
+    .array(searchDomainSchema)
+    .optional()
+    .describe('Exclude results from these hostnames.'),
   sources: z
-    .array(z.object({ type: z.enum(['web', 'images', 'news']) }))
-    .optional(),
+    .array(
+      z.object({
+        type: z
+          .enum(['web', 'images', 'news'])
+          .describe('Search source type.'),
+      })
+    )
+    .optional()
+    .describe('Source groups to search; defaults to web.'),
   categories: z
     .array(z.enum(['github', 'research', 'pdf', 'developer']))
     .optional()
     .describe(
       'Limit results to specific source types. `github` searches GitHub repositories, code, issues, and docs; `research` restricts ordinary web results to research-affiliated websites and returns page snippets, which is separate from the `firecrawl_research_*` tools that search paper abstracts and full text across biomedical (PubMed, bioRxiv, medRxiv) and arXiv literature; `pdf` searches PDF results; `developer` searches an index built for coding agents over GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. `developer` adds a `data.developer` group of `{ url, title, description }` results, where `description` holds the matched passage; the other categories filter `data.web`.'
     ),
-  enterprise: z.array(z.enum(['default', 'anon', 'zdr'])).optional(),
+  enterprise: z
+    .array(z.enum(['default', 'anon', 'zdr']))
+    .optional()
+    .describe('Enterprise search modes when enabled for the account.'),
   response_format: responseFormatSchema,
 };
 
@@ -1880,7 +1897,7 @@ function transformScrapeParams(
 }
 
 const scrapeParamsSchema = z.object({
-  url: z.string().url(),
+  url: z.string().url().describe('Page URL to scrape.'),
   formats: z
     .array(
       z.enum([
@@ -1897,75 +1914,146 @@ const scrapeParamsSchema = z.object({
         'audio',
       ])
     )
-    .optional(),
+    .optional()
+    .describe('Content formats to return.'),
   jsonOptions: z
     .object({
-      prompt: z.string().optional(),
-      schema: z.record(z.string(), z.any()).optional(),
+      prompt: z.string().optional().describe('Extraction instructions.'),
+      schema: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe('JSON Schema-like object defining extracted fields.'),
     })
-    .optional(),
+    .optional()
+    .describe('Structured JSON extraction configuration.'),
   queryOptions: z
     .object({
-      prompt: z.string().max(10000),
-      mode: z.enum(['directQuote', 'freeform']).default('freeform'),
+      prompt: z.string().max(10000).describe('Question about the page.'),
+      mode: z
+        .enum(['directQuote', 'freeform'])
+        .default('freeform')
+        .describe('Answer mode; defaults to freeform.'),
     })
-    .optional(),
+    .optional()
+    .describe('Targeted page-question configuration.'),
   screenshotOptions: z
     .object({
-      fullPage: z.boolean().optional(),
-      quality: z.number().optional(),
-      viewport: z.object({ width: z.number(), height: z.number() }).optional(),
+      fullPage: z.boolean().optional().describe('Capture the full page.'),
+      quality: z.number().optional().describe('Screenshot image quality.'),
+      viewport: z
+        .object({
+          width: z.number().describe('Viewport width in pixels.'),
+          height: z.number().describe('Viewport height in pixels.'),
+        })
+        .optional()
+        .describe('Screenshot viewport dimensions.'),
     })
-    .optional(),
-  parsers: z.array(z.enum(['pdf'])).optional(),
+    .optional()
+    .describe('Screenshot capture configuration.'),
+  parsers: z
+    .array(z.enum(['pdf']))
+    .optional()
+    .describe('Document parsers to enable.'),
   pdfOptions: z
     .object({
-      maxPages: z.number().int().min(1).max(10000).optional(),
+      maxPages: z
+        .number()
+        .int()
+        .min(1)
+        .max(10000)
+        .optional()
+        .describe('Maximum PDF pages to parse.'),
     })
-    .optional(),
-  onlyMainContent: z.boolean().optional(),
-  redactPII: z.boolean().optional(),
-  includeTags: z.array(z.string()).optional(),
-  excludeTags: z.array(z.string()).optional(),
-  waitFor: z.number().optional(),
+    .optional()
+    .describe('PDF parsing configuration.'),
+  onlyMainContent: z
+    .boolean()
+    .optional()
+    .describe('Exclude navigation, headers, and footers.'),
+  redactPII: z.boolean().optional().describe('Redact detected personal information.'),
+  includeTags: z
+    .array(z.string())
+    .optional()
+    .describe('Only include these HTML tags.'),
+  excludeTags: z
+    .array(z.string())
+    .optional()
+    .describe('Exclude these HTML tags.'),
+  waitFor: z.number().optional().describe('Render delay in milliseconds.'),
   ...(SAFE_MODE
     ? {}
     : {
         actions: z
           .array(
             z.object({
-              type: z.enum(allowedActionTypes),
-              selector: z.string().optional(),
-              milliseconds: z.number().optional(),
-              text: z.string().optional(),
-              key: z.string().optional(),
-              direction: z.enum(['up', 'down']).optional(),
-              script: z.string().optional(),
-              fullPage: z.boolean().optional(),
+              type: z.enum(allowedActionTypes).describe('Browser action type.'),
+              selector: z.string().optional().describe('Target CSS selector.'),
+              milliseconds: z
+                .number()
+                .optional()
+                .describe('Wait duration in milliseconds.'),
+              text: z.string().optional().describe('Text to enter.'),
+              key: z.string().optional().describe('Keyboard key to press.'),
+              direction: z
+                .enum(['up', 'down'])
+                .optional()
+                .describe('Scroll direction.'),
+              script: z.string().optional().describe('JavaScript to execute.'),
+              fullPage: z
+                .boolean()
+                .optional()
+                .describe('Capture the full page for screenshot actions.'),
             })
           )
-          .optional(),
+          .optional()
+          .describe('Ordered browser actions to perform before extraction.'),
       }),
-  mobile: z.boolean().optional(),
-  skipTlsVerification: z.boolean().optional(),
-  removeBase64Images: z.boolean().optional(),
+  mobile: z.boolean().optional().describe('Use a mobile device viewport.'),
+  skipTlsVerification: z
+    .boolean()
+    .optional()
+    .describe('Allow pages with invalid TLS certificates.'),
+  removeBase64Images: z
+    .boolean()
+    .optional()
+    .describe('Remove inline base64 images from output.'),
   location: z
     .object({
-      country: z.string().optional(),
-      languages: z.array(z.string()).optional(),
+      country: z.string().optional().describe('ISO country code.'),
+      languages: z
+        .array(z.string())
+        .optional()
+        .describe('Preferred language codes.'),
     })
-    .optional(),
-  storeInCache: z.boolean().optional(),
-  zeroDataRetention: z.boolean().optional(),
-  maxAge: z.number().optional(),
-  lockdown: z.boolean().optional(),
-  proxy: z.enum(['basic', 'stealth', 'enhanced', 'auto']).optional(),
+    .optional()
+    .describe('Locale used when loading the page.'),
+  storeInCache: z.boolean().optional().describe('Permit storing fetched content in cache.'),
+  zeroDataRetention: z
+    .boolean()
+    .optional()
+    .describe('Prevent Firecrawl from retaining request content when supported.'),
+  maxAge: z
+    .number()
+    .optional()
+    .describe('Maximum cached-content age in milliseconds; 0 forces live fetch.'),
+  lockdown: z
+    .boolean()
+    .optional()
+    .describe('Use cached content only; fail instead of fetching live.'),
+  proxy: z
+    .enum(['basic', 'stealth', 'enhanced', 'auto'])
+    .optional()
+    .describe('Proxy mode; stronger modes may use more credits.'),
   profile: z
     .object({
-      name: z.string(),
-      saveChanges: z.boolean().optional(),
+      name: z.string().describe('Browser profile name.'),
+      saveChanges: z
+        .boolean()
+        .optional()
+        .describe('Persist profile changes after scraping.'),
     })
-    .optional(),
+    .optional()
+    .describe('Reusable browser profile configuration.'),
   response_format: responseFormatSchema,
 });
 
@@ -1982,38 +2070,81 @@ const parseOptionParamsSchema = z.object({
         'query',
       ])
     )
-    .optional(),
+    .optional()
+    .describe('Parsed content formats to return.'),
   jsonOptions: z
     .object({
-      prompt: z.string().optional(),
-      schema: z.record(z.string(), z.any()).optional(),
+      prompt: z.string().optional().describe('Extraction instructions.'),
+      schema: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe('JSON Schema-like object defining extracted fields.'),
     })
-    .optional(),
+    .optional()
+    .describe('Structured JSON extraction configuration.'),
   queryOptions: z
     .object({
-      prompt: z.string().max(10000),
-      mode: z.enum(['directQuote', 'freeform']).default('freeform'),
+      prompt: z.string().max(10000).describe('Question about the document.'),
+      mode: z
+        .enum(['directQuote', 'freeform'])
+        .default('freeform')
+        .describe('Answer mode; defaults to freeform.'),
     })
-    .optional(),
-  parsers: z.array(z.enum(['pdf'])).optional(),
+    .optional()
+    .describe('Targeted document-question configuration.'),
+  parsers: z
+    .array(z.enum(['pdf']))
+    .optional()
+    .describe('Document parsers to enable.'),
   pdfOptions: z
     .object({
-      maxPages: z.number().int().min(1).max(10000).optional(),
+      maxPages: z
+        .number()
+        .int()
+        .min(1)
+        .max(10000)
+        .optional()
+        .describe('Maximum PDF pages to parse.'),
     })
-    .optional(),
-  onlyMainContent: z.boolean().optional(),
-  redactPII: z.boolean().optional(),
-  includeTags: z.array(z.string()).optional(),
-  excludeTags: z.array(z.string()).optional(),
-  removeBase64Images: z.boolean().optional(),
-  skipTlsVerification: z.boolean().optional(),
-  storeInCache: z.boolean().optional(),
-  zeroDataRetention: z.boolean().optional(),
+    .optional()
+    .describe('PDF parsing configuration.'),
+  onlyMainContent: z
+    .boolean()
+    .optional()
+    .describe('Exclude navigation, headers, and footers.'),
+  redactPII: z.boolean().optional().describe('Redact detected personal information.'),
+  includeTags: z
+    .array(z.string())
+    .optional()
+    .describe('Only include these HTML tags.'),
+  excludeTags: z
+    .array(z.string())
+    .optional()
+    .describe('Exclude these HTML tags.'),
+  removeBase64Images: z
+    .boolean()
+    .optional()
+    .describe('Remove inline base64 images from output.'),
+  skipTlsVerification: z
+    .boolean()
+    .optional()
+    .describe('Allow source URLs with invalid TLS certificates.'),
+  storeInCache: z
+    .boolean()
+    .optional()
+    .describe('Ignored: parse does not store indexed content.'),
+  zeroDataRetention: z
+    .boolean()
+    .optional()
+    .describe('Prevent Firecrawl from retaining document content when supported.'),
   maxAge: z
     .number()
     .optional()
     .describe('Ignored: parse never reuses or stores indexed content.'),
-  proxy: z.enum(['basic', 'auto']).optional(),
+  proxy: z
+    .enum(['basic', 'auto'])
+    .optional()
+    .describe('Proxy mode used for remote document URLs.'),
   response_format: responseFormatSchema,
 });
 
@@ -2442,12 +2573,21 @@ Enumerate URLs indexed under one website through Firecrawl without fetching each
 Returns matching URLs rather than page bodies. Retrieve one page with \`firecrawl_scrape\`; collect content across multiple pages with \`firecrawl_crawl\`.
 `,
   parameters: z.object({
-    url: z.string().url(),
-    search: z.string().optional(),
-    sitemap: z.enum(['include', 'skip', 'only']).optional(),
-    includeSubdomains: z.boolean().optional(),
-    limit: z.number().optional(),
-    ignoreQueryParameters: z.boolean().optional(),
+    url: z.string().url().describe('Website root URL to map.'),
+    search: z.string().optional().describe('Term used to rank matching URLs.'),
+    sitemap: z
+      .enum(['include', 'skip', 'only'])
+      .optional()
+      .describe('Whether sitemap URLs are included, skipped, or exclusive.'),
+    includeSubdomains: z
+      .boolean()
+      .optional()
+      .describe('Include URLs from subdomains.'),
+    limit: z.number().optional().describe('Maximum number of URLs returned.'),
+    ignoreQueryParameters: z
+      .boolean()
+      .optional()
+      .describe('Deduplicate URLs that differ only by query parameters.'),
   }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
     const { url, ...options } = args as { url: string } & Record<
@@ -2492,7 +2632,10 @@ For a programming question, add \`categories: ["developer"]\`. It searches an in
       scrapeOptions: scrapeParamsSchema
         .omit({ url: true, response_format: true })
         .partial()
-        .optional(),
+        .optional()
+        .describe(
+          'Scrape configuration applied to each result. Fetching full page content increases response size and credit use.'
+        ),
     })
     .refine(searchDomainsAreExclusive, SEARCH_DOMAINS_CONFLICT_MESSAGE),
   execute: async (args: unknown, { session, log }): Promise<string> => {
@@ -2793,16 +2936,25 @@ const feedbackIssueSchema = z
   );
 
 const valuableSourceSchema = z.object({
-  url: z.string().url(),
-  reason: z.string().max(1000).optional(),
+  url: z.string().url().describe('Useful source URL.'),
+  reason: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe('Why this source was useful.'),
 });
 
 const missingContentSchema = z.object({
   topic: z
     .string()
     .min(1, 'topic must not be empty')
-    .max(200, 'topic must be 200 characters or fewer'),
-  description: z.string().max(2000).optional(),
+    .max(200, 'topic must be 200 characters or fewer')
+    .describe('Short name for the missing topic.'),
+  description: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe('Details about the expected missing content.'),
 });
 
 const FEEDBACK_DISABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
@@ -2846,25 +2998,38 @@ Eligibility is limited to successful searches within the feedback age window. Th
     parameters: z.object({
       searchId: z
         .string()
-        .uuid('searchId must be the UUID returned by firecrawl_search'),
-      rating: z.enum(['good', 'bad', 'partial']),
+        .uuid('searchId must be the UUID returned by firecrawl_search')
+        .describe('UUID returned by firecrawl_search.'),
+      rating: z
+        .enum(['good', 'bad', 'partial'])
+        .describe('Overall search-result quality rating.'),
       valuableSources: z
         .array(
           z.object({
-            url: z.string().url(),
-            reason: z.string().max(1000).optional(),
+            url: z.string().url().describe('Useful result URL.'),
+            reason: z
+              .string()
+              .max(1000)
+              .optional()
+              .describe('Why this source was useful.'),
           })
         )
         .max(50)
-        .optional(),
+        .optional()
+        .describe('Useful sources from the search; maximum 50.'),
       missingContent: z
         .array(
           z.object({
             topic: z
               .string()
               .min(1, 'topic must not be empty')
-              .max(200, 'topic must be 200 characters or fewer'),
-            description: z.string().max(2000).optional(),
+              .max(200, 'topic must be 200 characters or fewer')
+              .describe('Short name for the missing topic.'),
+            description: z
+              .string()
+              .max(2000)
+              .optional()
+              .describe('Details about the expected missing content.'),
           })
         )
         .max(20)
@@ -2874,7 +3039,11 @@ Eligibility is limited to successful searches within the feedback age window. Th
             'One entry per distinct topic. Each entry has a short `topic` and optional ' +
             'longer `description`.'
         ),
-      querySuggestions: z.string().max(2000).optional(),
+      querySuggestions: z
+        .string()
+        .max(2000)
+        .optional()
+        .describe('Suggested query improvements; maximum 2000 characters.'),
     }),
     execute: async (args: unknown, { session, log }): Promise<string> => {
       const {
@@ -2984,18 +3153,56 @@ Submit concise quality feedback for a completed search, scrape, parse, or map jo
 Returns submission status, feedback ID, and accounting fields.
 `,
     parameters: z.object({
-      endpoint: z.enum(['search', 'scrape', 'parse', 'map']),
-      jobId: z.string().uuid('jobId must be the UUID returned by Firecrawl'),
-      rating: z.enum(['good', 'bad', 'partial']),
-      issues: z.array(feedbackIssueSchema).max(20).optional(),
-      tags: z.array(feedbackIssueSchema).max(20).optional(),
-      note: z.string().max(4000).optional(),
-      valuableSources: z.array(valuableSourceSchema).max(50).optional(),
-      missingContent: z.array(missingContentSchema).max(50).optional(),
-      querySuggestions: z.string().max(2000).optional(),
-      url: z.string().url().optional(),
-      pageNumbers: z.array(z.number().int().positive()).max(100).optional(),
-      metadata: z.record(z.string(), z.unknown()).optional(),
+      endpoint: z
+        .enum(['search', 'scrape', 'parse', 'map'])
+        .describe('Firecrawl operation being rated.'),
+      jobId: z
+        .string()
+        .uuid('jobId must be the UUID returned by Firecrawl')
+        .describe('UUID returned by the rated Firecrawl operation.'),
+      rating: z
+        .enum(['good', 'bad', 'partial'])
+        .describe('Overall operation-result quality rating.'),
+      issues: z
+        .array(feedbackIssueSchema)
+        .max(20)
+        .optional()
+        .describe('Machine-readable issue codes; maximum 20.'),
+      tags: z
+        .array(feedbackIssueSchema)
+        .max(20)
+        .optional()
+        .describe('Additional classification tags; maximum 20.'),
+      note: z
+        .string()
+        .max(4000)
+        .optional()
+        .describe('Concise feedback note; maximum 4000 characters.'),
+      valuableSources: z
+        .array(valuableSourceSchema)
+        .max(50)
+        .optional()
+        .describe('Useful sources from the result; maximum 50.'),
+      missingContent: z
+        .array(missingContentSchema)
+        .max(50)
+        .optional()
+        .describe('Expected content absent from the result; maximum 50.'),
+      querySuggestions: z
+        .string()
+        .max(2000)
+        .optional()
+        .describe('Suggested query improvements; maximum 2000 characters.'),
+      url: z.string().url().optional().describe('Relevant source URL.'),
+      pageNumbers: z
+        .array(z.number().int().positive())
+        .max(100)
+        .optional()
+        .describe('Relevant one-based page numbers; maximum 100.'),
+      metadata: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('Small structured context for the feedback.'),
     }),
     execute: async (args: unknown, { session, log }): Promise<string> => {
       const {
@@ -3109,30 +3316,66 @@ Start a multi-page crawl at a website URL, poll it to a terminal state, and retu
 Crawl results can be large; use conservative limits when full-site coverage is unnecessary. Webhooks and interactive scrape actions are unavailable in safe mode. Returns the crawl ID, status, page data, and a \`next\` continuation when more pages remain. \`response_format\` defaults to \`detailed\`.
 `,
   parameters: z.object({
-    url: z.string(),
-    prompt: z.string().optional(),
-    excludePaths: z.array(z.string()).optional(),
-    includePaths: z.array(z.string()).optional(),
-    maxDiscoveryDepth: z.number().optional(),
-    sitemap: z.enum(['skip', 'include', 'only']).optional(),
-    limit: z.number().optional(),
-    allowExternalLinks: z.boolean().optional(),
-    allowSubdomains: z.boolean().optional(),
-    crawlEntireDomain: z.boolean().optional(),
-    delay: z.number().optional(),
-    maxConcurrency: z.number().optional(),
+    url: z.string().describe('Website URL where the crawl starts.'),
+    prompt: z.string().optional().describe('Natural-language crawl scope instructions.'),
+    excludePaths: z
+      .array(z.string())
+      .optional()
+      .describe('URL path patterns to exclude.'),
+    includePaths: z
+      .array(z.string())
+      .optional()
+      .describe('URL path patterns to include.'),
+    maxDiscoveryDepth: z
+      .number()
+      .optional()
+      .describe('Maximum link depth from the starting URL.'),
+    sitemap: z
+      .enum(['skip', 'include', 'only'])
+      .optional()
+      .describe('Whether sitemap URLs are skipped, included, or exclusive.'),
+    limit: z.number().optional().describe('Maximum pages to crawl.'),
+    allowExternalLinks: z
+      .boolean()
+      .optional()
+      .describe('Allow crawling links outside the starting domain.'),
+    allowSubdomains: z
+      .boolean()
+      .optional()
+      .describe('Allow crawling subdomains.'),
+    crawlEntireDomain: z
+      .boolean()
+      .optional()
+      .describe('Expand beyond the starting URL path.'),
+    delay: z.number().optional().describe('Delay between requests in seconds.'),
+    maxConcurrency: z
+      .number()
+      .optional()
+      .describe('Maximum concurrent crawl requests.'),
     ...(SAFE_MODE
       ? {}
       : {
-          webhook: z.string().optional(),
-          webhookHeaders: z.record(z.string(), z.string()).optional(),
+          webhook: z.string().optional().describe('Webhook URL for crawl events.'),
+          webhookHeaders: z
+            .record(z.string(), z.string())
+            .optional()
+            .describe('HTTP headers sent to the crawl webhook.'),
         }),
-    deduplicateSimilarURLs: z.boolean().optional(),
-    ignoreQueryParameters: z.boolean().optional(),
+    deduplicateSimilarURLs: z
+      .boolean()
+      .optional()
+      .describe('Remove URLs with substantially similar paths.'),
+    ignoreQueryParameters: z
+      .boolean()
+      .optional()
+      .describe('Deduplicate URLs that differ only by query parameters.'),
     scrapeOptions: scrapeParamsSchema
       .omit({ url: true, response_format: true })
       .partial()
-      .optional(),
+      .optional()
+      .describe(
+        'Scrape configuration applied to every crawled page. Rich formats increase response size and credit use.'
+      ),
     response_format: responseFormatSchema,
   }),
   execute: async (args, { session, log }) => {
@@ -3212,8 +3455,12 @@ server.addTool({
 Retrieve the current status, progress, and available results for an existing crawl ID. This only reads Firecrawl job state and does not start or modify the crawl. When \`next\` is returned, pass it with the same ID to retrieve later documents. \`response_format\` defaults to \`detailed\`.
 `,
   parameters: z.object({
-    id: z.string(),
-    next: z.string().max(4_096).optional(),
+    id: z.string().describe('Crawl job ID.'),
+    next: z
+      .string()
+      .max(4_096)
+      .optional()
+      .describe('Continuation URL returned by a previous status call.'),
     response_format: responseFormatSchema,
   }),
   execute: async (
@@ -3289,9 +3536,21 @@ Start an asynchronous web research job from a prompt, optional seed URLs, and an
 This call returns only a job ID, not the research result. Read the job with \`firecrawl_agent_status\` until it reaches \`completed\` or \`failed\`; research commonly takes several minutes. If the job cannot finish within the task's available time, \`firecrawl_search\` and \`firecrawl_scrape\` can gather evidence synchronously.
 `,
   parameters: z.object({
-    prompt: z.string().min(1).max(10000),
-    urls: z.array(z.string().url()).optional(),
-    schema: z.record(z.string(), z.any()).optional(),
+    prompt: z
+      .string()
+      .min(1)
+      .max(10000)
+      .describe('Research question and requested output.'),
+    urls: z
+      .array(z.string().url())
+      .optional()
+      .describe('Optional seed URLs for the research job.'),
+    schema: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe(
+        'JSON Schema-like object defining the final structured result. Narrow schemas reduce result size.'
+      ),
   }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
     const client = getClient(session);
@@ -3327,7 +3586,7 @@ Retrieve progress or final results for a \`firecrawl_agent\` job ID. A \`process
 Returns job status, progress information, and result data when completed. \`response_format\` defaults to \`detailed\`; \`concise\` removes bulky duplicate content and reports omissions.
 `,
   parameters: z.object({
-    id: z.string(),
+    id: z.string().describe('Agent job ID.'),
     response_format: responseFormatSchema,
   }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
@@ -3365,16 +3624,45 @@ This acts on the live site, so actions such as form submission can create persis
 `,
   parameters: z
     .object({
-      scrapeId: z.string().trim().min(1).optional(),
-      url: z.string().trim().url().optional(),
-      prompt: z.string().trim().min(1).optional(),
-      code: z.string().trim().min(1).optional(),
-      language: z.enum(['bash', 'python', 'node']).optional(),
-      timeout: z.number().min(1).max(300).optional(),
+      scrapeId: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe('Existing scrape session ID; mutually exclusive with url.'),
+      url: z
+        .string()
+        .trim()
+        .url()
+        .optional()
+        .describe('Page URL to open; mutually exclusive with scrapeId.'),
+      prompt: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe('Natural-language browser interaction instructions.'),
+      code: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe('Executable browser-session code; may accompany prompt.'),
+      language: z
+        .enum(['bash', 'python', 'node'])
+        .optional()
+        .describe('Code runtime; used only with code.'),
+      timeout: z
+        .number()
+        .min(1)
+        .max(300)
+        .optional()
+        .describe('Execution timeout in seconds; maximum 300.'),
       scrapeOptions: scrapeParamsSchema
         .omit({ url: true, response_format: true })
         .partial()
-        .optional(),
+        .optional()
+        .describe('Scrape configuration used only when opening url.'),
       response_format: responseFormatSchema,
     })
     .refine((data) => Boolean(data.scrapeId) !== Boolean(data.url), {
@@ -3482,7 +3770,7 @@ server.addTool({
 Stop the live interact session associated with a \`scrapeId\` and release its resources. Returns a success confirmation.
 `,
   parameters: z.object({
-    scrapeId: z.string(),
+    scrapeId: z.string().describe('Interact session ID to stop.'),
   }),
   execute: async (args: unknown, { session, log }): Promise<string> => {
     const client = getClient(session);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2296,7 +2296,7 @@ type ParseToolArgs = Omit<HostedParseToolArgs, 'filePath' | 'uploadRef'> &
   );
 
 function extractParseOptions(args: ParseToolArgs): Record<string, unknown> {
-  const options = { ...args };
+  const options: Record<string, unknown> = { ...args };
   delete options.filePath;
   delete options.uploadRef;
   delete options.contentType;
@@ -3835,7 +3835,7 @@ Open or reuse a live browser session to interact with a page by prompt or code. 
     // session, then interact. One tool call instead of scrape + interact.
     let scrapeId = providedScrapeId;
     const openedFromUrl = !scrapeId;
-    if (openedFromUrl) {
+    if (!scrapeId) {
       log.info('Opening interact session from url', { url });
       const cleanedScrapeOptions = removeEmptyTopLevel(scrapeOptions ?? {});
       const scraped = await client.scrape(String(url), {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -229,21 +229,50 @@ Create a recurring scrape, crawl, or search monitor that compares each check wit
 In the simple form, a \`goal\` is required. If \`queries\` contains one or more non-empty values and is supplied with \`page\`/\`pages\`, \`queries\` create the search target and page targets are ignored. A monitor schedules future network checks and can send configured email or webhook notifications. Returns the created monitor.
 `,
     parameters: z.object({
-      body: z.record(z.string(), z.any()).optional(),
-      page: z.string().optional(),
-      pages: z.array(z.string()).optional(),
-      queries: z.array(z.string()).optional(),
-      searchWindow: z.enum(['5m', '15m', '1h', '6h', '24h', '7d']).optional(),
-      maxResults: z.number().int().min(1).max(50).optional(),
-      includeDomains: z.array(z.string()).optional(),
-      excludeDomains: z.array(z.string()).optional(),
-      goal: z.string().optional(),
-      name: z.string().optional(),
-      scheduleText: z.string().optional(),
-      timezone: z.string().optional(),
-      email: z.string().optional(),
-      includeDiffs: z.boolean().optional(),
-      webhookUrl: z.string().optional(),
+      body: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe(
+          'Advanced monitor request body. When provided, it replaces the simple-form fields.'
+        ),
+      page: z.string().optional().describe('Single page URL to monitor.'),
+      pages: z.array(z.string()).optional().describe('Page URLs to monitor.'),
+      queries: z
+        .array(z.string())
+        .optional()
+        .describe('Search queries to monitor; these take precedence over pages.'),
+      searchWindow: z
+        .enum(['5m', '15m', '1h', '6h', '24h', '7d'])
+        .optional()
+        .describe('Lookback window for monitored search results.'),
+      maxResults: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe('Maximum search results per check; maximum 50.'),
+      includeDomains: z
+        .array(z.string())
+        .optional()
+        .describe('Only include search results from these domains.'),
+      excludeDomains: z
+        .array(z.string())
+        .optional()
+        .describe('Exclude search results from these domains.'),
+      goal: z.string().optional().describe('Change-detection goal; required in simple form.'),
+      name: z.string().optional().describe('Monitor display name.'),
+      scheduleText: z
+        .string()
+        .optional()
+        .describe('Plain-language schedule; defaults to every 30 minutes.'),
+      timezone: z.string().optional().describe('IANA timezone; defaults to UTC.'),
+      email: z.string().optional().describe('Notification email address.'),
+      includeDiffs: z
+        .boolean()
+        .optional()
+        .describe('Include content diffs in check results.'),
+      webhookUrl: z.string().optional().describe('Webhook URL for monitor events.'),
     }),
     execute: async (args: unknown, { session, log }): Promise<string> => {
       const body = buildMonitorCreateBody(args as Record<string, unknown>);
@@ -268,8 +297,18 @@ In the simple form, a \`goal\` is required. If \`queries\` contains one or more 
 List monitors for the authenticated account with optional pagination controls. Returns one page of monitor records and pagination metadata.
 `,
     parameters: z.object({
-      limit: z.number().int().positive().optional(),
-      offset: z.number().int().nonnegative().optional(),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Maximum monitors returned.'),
+      offset: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Zero-based pagination offset.'),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { limit, offset } = args as { limit?: number; offset?: number };
@@ -291,7 +330,7 @@ List monitors for the authenticated account with optional pagination controls. R
     description: `
 Retrieve one monitor by ID, including its configuration and current state. This does not run or modify the monitor.
 `,
-    parameters: z.object({ id: z.string() }),
+    parameters: z.object({ id: z.string().describe('Monitor ID.') }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { id } = args as { id: string };
       const res = await monitorRequest(
@@ -316,8 +355,10 @@ Patch an existing monitor by ID. The body can change its name, active/paused sta
 Returns the updated monitor.
 `,
     parameters: z.object({
-      id: z.string(),
-      body: z.record(z.string(), z.any()),
+      id: z.string().describe('Monitor ID.'),
+      body: z
+        .record(z.string(), z.any())
+        .describe('Partial monitor fields to update.'),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { id, body } = args as {
@@ -344,7 +385,7 @@ Returns the updated monitor.
     description: `
 Permanently delete a monitor by ID and stop its future schedule. This operation cannot be undone and returns deletion status.
 `,
-    parameters: z.object({ id: z.string() }),
+    parameters: z.object({ id: z.string().describe('Monitor ID.') }),
     execute: async (args: unknown, { session, log }): Promise<string> => {
       const { id } = args as { id: string };
       log.info('Deleting monitor', { id });
@@ -368,7 +409,7 @@ Permanently delete a monitor by ID and stop its future schedule. This operation 
     description: `
 Queue an immediate check for a monitor outside its normal schedule. This starts network work for the monitor's configured targets and returns the queued check.
 `,
-    parameters: z.object({ id: z.string() }),
+    parameters: z.object({ id: z.string().describe('Monitor ID.') }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { id } = args as { id: string };
       const res = await monitorRequest(
@@ -392,10 +433,20 @@ Queue an immediate check for a monitor outside its normal schedule. This starts 
 List historical checks for a monitor, optionally filtered by status and bounded by a result limit. Returns one page of check summaries and pagination metadata.
 `,
     parameters: z.object({
-      id: z.string(),
-      limit: z.number().int().positive().optional(),
-      offset: z.number().int().nonnegative().optional(),
-      status: checkStatusSchema.optional(),
+      id: z.string().describe('Monitor ID.'),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Maximum checks returned.'),
+      offset: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Zero-based pagination offset.'),
+      status: checkStatusSchema.optional().describe('Filter checks by status.'),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { id, limit, offset, status } = args as {
@@ -427,11 +478,21 @@ Retrieve one monitor check and its page-level results, optionally filtered by pa
 Markdown tracking returns a unified text diff, JSON tracking returns field paths with previous/current values and a current snapshot, and mixed tracking returns both. Returns one page of results plus a \`next\` URL when more pages exist.
 `,
     parameters: z.object({
-      id: z.string(),
-      checkId: z.string(),
-      limit: z.number().int().positive().optional(),
-      skip: z.number().int().nonnegative().optional(),
-      pageStatus: pageStatusSchema.optional(),
+      id: z.string().describe('Monitor ID.'),
+      checkId: z.string().describe('Monitor check ID.'),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Maximum page results returned.'),
+      skip: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Number of page results to skip.'),
+      pageStatus: pageStatusSchema.optional().describe('Filter pages by status.'),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { id, checkId, limit, skip, pageStatus } = args as {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -60,7 +60,7 @@ async function monitorRequest(
   if (init.query) {
     const qs = new URLSearchParams();
     for (const [k, v] of Object.entries(init.query)) {
-      if (v !== undefined && v !== null && v !== '') qs.set(k, String(v));
+      if (v !== undefined && v !== '') qs.set(k, String(v));
     }
     const s = qs.toString();
     if (s) url += `?${s}`;
@@ -109,6 +109,12 @@ function splitPages(page?: string, pages?: string[]): string[] {
     .filter(Boolean);
 }
 
+function stringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : undefined;
+}
+
 function buildMonitorCreateBody(
   args: Record<string, unknown>
 ): Record<string, unknown> {
@@ -144,16 +150,8 @@ function buildMonitorCreateBody(
   // Build the target: search when `queries` are given, otherwise a scrape.
   let target: Record<string, unknown>;
   if (isSearch) {
-    const includeDomains = Array.isArray(args.includeDomains)
-      ? (args.includeDomains as unknown[]).filter(
-          (d): d is string => typeof d === 'string'
-        )
-      : undefined;
-    const excludeDomains = Array.isArray(args.excludeDomains)
-      ? (args.excludeDomains as unknown[]).filter(
-          (d): d is string => typeof d === 'string'
-        )
-      : undefined;
+    const includeDomains = stringArray(args.includeDomains);
+    const excludeDomains = stringArray(args.excludeDomains);
     target = {
       type: 'search',
       queries,

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -224,9 +224,7 @@ export function registerMonitorTools(server: FastMCP<SessionData>): void {
       destructiveHint: false, // Additive; creates a new monitor without deleting existing monitors or external content.
     },
     description: `
-Create a recurring scrape, crawl, or search monitor that compares each check with its retained predecessor. The simple form accepts \`page\`/\`pages\` or \`queries\` plus a plain-language \`goal\`; the advanced \`body\` form controls targets, schedule, change-tracking formats, judging, retention, webhook, and notifications.
-
-In the simple form, a \`goal\` is required. If \`queries\` contains one or more non-empty values and is supplied with \`page\`/\`pages\`, \`queries\` create the search target and page targets are ignored. A monitor schedules future network checks and can send configured email or webhook notifications. Returns the created monitor.
+Create a recurring page, site, or search monitor that compares checks over time. In the simple form a \`goal\` is required; when \`queries\` and pages are both supplied, queries create the search target and page targets are ignored. Monitors schedule future network checks and may send configured notifications.
 `,
     parameters: z.object({
       body: z
@@ -294,7 +292,7 @@ In the simple form, a \`goal\` is required. If \`queries\` contains one or more 
       destructiveHint: false, // Read-only listing.
     },
     description: `
-List monitors for the authenticated account with optional pagination controls. Returns one page of monitor records and pagination metadata.
+List monitors for the authenticated account. This reads configurations without running or modifying them.
 `,
     parameters: z.object({
       limit: z
@@ -328,7 +326,7 @@ List monitors for the authenticated account with optional pagination controls. R
       destructiveHint: false, // Read-only retrieval.
     },
     description: `
-Retrieve one monitor by ID, including its configuration and current state. This does not run or modify the monitor.
+Retrieve one monitor's configuration and state by ID without running or modifying it.
 `,
     parameters: z.object({ id: z.string().describe('Monitor ID.') }),
     execute: async (args: unknown, { session }): Promise<string> => {
@@ -350,9 +348,7 @@ Retrieve one monitor by ID, including its configuration and current state. This 
       destructiveHint: true, // Can pause, replace, or remove monitor configuration; changes overwrite prior settings.
     },
     description: `
-Patch an existing monitor by ID. The body can change its name, active/paused status, schedule, targets, goal, judging, webhook, notifications, or retention; these changes affect future scheduled checks.
-
-Returns the updated monitor.
+Patch an existing monitor's configuration by ID. Changes affect future scheduled checks but do not run a check immediately.
 `,
     parameters: z.object({
       id: z.string().describe('Monitor ID.'),
@@ -383,7 +379,7 @@ Returns the updated monitor.
       destructiveHint: true, // Irreversibly removes the monitor and stops its schedule.
     },
     description: `
-Permanently delete a monitor by ID and stop its future schedule. This operation cannot be undone and returns deletion status.
+Permanently delete a monitor and stop its future schedule. This operation cannot be undone.
 `,
     parameters: z.object({ id: z.string().describe('Monitor ID.') }),
     execute: async (args: unknown, { session, log }): Promise<string> => {
@@ -407,7 +403,7 @@ Permanently delete a monitor by ID and stop its future schedule. This operation 
       destructiveHint: false, // Starts a read-only check job; does not delete the monitor or external sites.
     },
     description: `
-Queue an immediate check for a monitor outside its normal schedule. This starts network work for the monitor's configured targets and returns the queued check.
+Queue an immediate check for a monitor outside its schedule. This starts network work without changing the schedule.
 `,
     parameters: z.object({ id: z.string().describe('Monitor ID.') }),
     execute: async (args: unknown, { session }): Promise<string> => {
@@ -430,7 +426,7 @@ Queue an immediate check for a monitor outside its normal schedule. This starts 
       destructiveHint: false, // Read-only listing.
     },
     description: `
-List historical checks for a monitor, optionally filtered by status and bounded by a result limit. Returns one page of check summaries and pagination metadata.
+List historical checks for a monitor. This reads check summaries without running a new check.
 `,
     parameters: z.object({
       id: z.string().describe('Monitor ID.'),
@@ -473,9 +469,7 @@ List historical checks for a monitor, optionally filtered by status and bounded 
       destructiveHint: false, // Read-only retrieval of diff snapshots and judgments.
     },
     description: `
-Retrieve one monitor check and its page-level results, optionally filtered by page status. Pages report \`same\`, \`new\`, \`changed\`, \`removed\`, or \`error\`; configured goal judging can add a meaningful-change decision.
-
-Markdown tracking returns a unified text diff, JSON tracking returns field paths with previous/current values and a current snapshot, and mixed tracking returns both. Returns one page of results plus a \`next\` URL when more pages exist.
+Retrieve one monitor check and its page-level change results. Use this for stored diffs and judgments; it does not run or modify the monitor.
 `,
     parameters: z.object({
       id: z.string().describe('Monitor ID.'),

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -222,7 +222,7 @@ export function registerMonitorTools(server: FastMCP<SessionData>): void {
       destructiveHint: false, // Additive; creates a new monitor without deleting existing monitors or external content.
     },
     description: `
-Create a recurring page, site, or search monitor that compares checks over time. In the simple form a \`goal\` is required; when \`queries\` and pages are both supplied, queries create the search target and page targets are ignored. Monitors schedule future network checks and may send configured notifications.
+Create a recurring page, site, or search monitor that compares checks over time. In the simple form a \`goal\` is required; when \`queries\` (one or more non-empty values) and pages are both supplied, queries create the search target and page targets are ignored. Monitors schedule future network checks and may send configured notifications.
 `,
     parameters: z.object({
       body: z
@@ -236,7 +236,9 @@ Create a recurring page, site, or search monitor that compares checks over time.
       queries: z
         .array(z.string())
         .optional()
-        .describe('Search queries to monitor; these take precedence over pages.'),
+        .describe(
+          'Search queries to monitor; non-empty queries take precedence over pages.'
+        ),
       searchWindow: z
         .enum(['5m', '15m', '1h', '6h', '24h', '7d'])
         .optional()

--- a/src/research.ts
+++ b/src/research.ts
@@ -241,11 +241,7 @@ export function registerResearchTools(
       destructiveHint: false, // Query-only; no writes to external sources or the research index.
     },
     description: `
-Search paper metadata and abstracts with a natural-language query across the indexed corpus, which spans biomedical, life-science, and clinical literature (PubMed, bioRxiv, medRxiv) alongside arXiv and other scientific sources. Optional author, category, and date filters constrain results.
-
-Several distinct framings of the same question surface different papers than a single query does.
-
-Returns ranked papers with canonical IDs, titles, authors, and abstracts.
+Search paper metadata and abstracts across an indexed corpus spanning biomedical literature (PubMed, bioRxiv, medRxiv) and arXiv. Use this for literature discovery; \`firecrawl_research_read_paper\` retrieves passages from a known paper.
 `,
     parameters: z.object({
       query: z
@@ -322,7 +318,7 @@ Returns ranked papers with canonical IDs, titles, authors, and abstracts.
       destructiveHint: false, // Read-only metadata lookup.
     },
     description: `
-Retrieve canonical metadata for one paper ID, such as an arXiv, PMC, PMID, or DOI identifier. Returns the title, abstract, authors, categories, source IDs, and dates as markdown.
+Retrieve metadata and abstract for one known paper ID. This does not retrieve full-text passages; use \`firecrawl_research_read_paper\` for those.
 `,
     parameters: z.object({
       paperId: z
@@ -353,9 +349,7 @@ Retrieve canonical metadata for one paper ID, such as an arXiv, PMC, PMID, or DO
       destructiveHint: false, // Read-only graph query; no modifications.
     },
     description: `
-Find citation-graph candidates from one to ten \`seed_ids\`; the first ID is the primary seed and later IDs are anchors. \`mode\` defaults to \`similar\` (co-citation/bibliographic coupling); \`citers\` returns papers citing a seed and \`references\` papers cited by a seed. \`intent\` ranks candidates.
-
-Returns ranked candidates and the evaluated pool size.
+Find citation-graph candidates from \`seed_ids\`; the first ID is the primary seed and later IDs are anchors. \`mode\` defaults to \`similar\`; \`citers\` finds citing papers and \`references\` finds cited papers.
 `,
     parameters: z.object({
       seed_ids: z
@@ -424,9 +418,7 @@ Returns ranked candidates and the evaluated pool size.
       destructiveHint: false, // Read-only passage retrieval.
     },
     description: `
-Retrieve in-body passages from one paper that are relevant to a specific question. Full text is available only for indexed papers; \`k\` controls the number of passages.
-
-Returns matching passages or a notice when full text is unavailable.
+Retrieve passages from one known paper that are relevant to a question. Full text is available only for indexed papers; use paper search to discover IDs.
 `,
     parameters: z.object({
       paperId: z
@@ -475,7 +467,7 @@ Returns matching passages or a notice when full text is unavailable.
       destructiveHint: false, // Query-only; does not create issues, PRs, or modify repositories.
     },
     description: `
-Search indexed public GitHub issue, pull-request, and README content. Returns ranked matches with repository, URL, snippet, and full matched markdown when available.
+Search indexed public GitHub issues, pull requests, and READMEs. Use for repository history or discussions rather than general web results.
 `,
     parameters: z.object({
       query: z.string().min(1).describe('GitHub issue, pull-request, or README search query.'),

--- a/src/research.ts
+++ b/src/research.ts
@@ -19,7 +19,7 @@ interface SessionData {
 }
 
 /** Whatever `getClient` returns — we only touch its `http.get`. */
-type ClientLike = {
+export type ClientLike = {
   http: {
     get: <T = unknown>(
       endpoint: string,
@@ -30,10 +30,10 @@ type ClientLike = {
 
 // `getClient` returns a FirecrawlApp whose `http` member is private, so we type
 // the callback loosely and narrow to `ClientLike` at each call site.
-type GetClient = (session?: SessionData) => unknown;
+export type GetClient = (session?: SessionData) => unknown;
 
 const BASE = '/v2/search/research';
-const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
+export const ORIGIN_HEADERS = { 'X-Origin': 'mcp-fastmcp' };
 
 /** Append a value (or repeated array values) to a URLSearchParams instance. */
 function appendParam(
@@ -389,7 +389,7 @@ Find citation-graph candidates from \`seed_ids\`; the first ID is the primary se
       appendParam(params, 'intent', intent);
       appendParam(params, 'mode', mode);
       appendParam(params, 'k', k);
-      if (rerank != null) appendParam(params, 'rerank', rerank);
+      appendParam(params, 'rerank', rerank);
       appendParam(params, 'anchor', anchors);
       const client = getClient(session) as ClientLike;
       const res = await client.http.get<{

--- a/src/research.ts
+++ b/src/research.ts
@@ -56,7 +56,7 @@ function withQuery(path: string, params: URLSearchParams): string {
   return qs ? `${path}?${qs}` : path;
 }
 
-// --- result formatting (ported from research-index-front/src/agent_eval.ts) ---
+// --- result formatting ---
 
 // Max authors to print per paper (with affiliations); the rest collapse to a
 // "+N more" tail so a large collaboration doesn't flood the context.

--- a/src/research.ts
+++ b/src/research.ts
@@ -358,10 +358,23 @@ Find citation-graph candidates from one to ten \`seed_ids\`; the first ID is the
 Returns ranked candidates and the evaluated pool size.
 `,
     parameters: z.object({
-      seed_ids: z.array(z.string()).min(1).max(10),
-      intent: z.string().min(1),
-      mode: z.enum(['similar', 'citers', 'references']).optional(),
-      k: z.number().int().min(1).max(500).optional(),
+      seed_ids: z
+        .array(z.string())
+        .min(1)
+        .max(10)
+        .describe('Paper IDs; first is primary and later IDs are anchors.'),
+      intent: z.string().min(1).describe('Question used to rank related papers.'),
+      mode: z
+        .enum(['similar', 'citers', 'references'])
+        .optional()
+        .describe('Citation relationship mode; defaults to similar.'),
+      k: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .optional()
+        .describe('Number of ranked papers to return.'),
       rerank: z
         .boolean()
         .optional()
@@ -422,7 +435,7 @@ Returns matching passages or a notice when full text is unavailable.
         .describe(
           'Canonical paperId or primaryId such as `arxiv:1706.03762`, `pmcid:PMC12530322`, `pmid:40953549`, or `doi:10.1016/j.neunet.2025.108095`.'
         ),
-      question: z.string().min(1),
+      question: z.string().min(1).describe('Question used to select full-text passages.'),
       k: z
         .number()
         .int()
@@ -465,8 +478,14 @@ Returns matching passages or a notice when full text is unavailable.
 Search indexed public GitHub issue, pull-request, and README content. Returns ranked matches with repository, URL, snippet, and full matched markdown when available.
 `,
     parameters: z.object({
-      query: z.string().min(1),
-      k: z.number().int().min(1).max(100).optional(),
+      query: z.string().min(1).describe('GitHub issue, pull-request, or README search query.'),
+      k: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Number of ranked results to return.'),
     }),
     execute: async (args: unknown, { session }): Promise<string> => {
       const { query, k } = args as { query: string; k?: number };

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -62,11 +62,11 @@ export function spawnServer(env) {
 
 export async function stopChild(child) {
   if (child.exitCode !== null) return;
+  const exited = new Promise((resolve) => child.once('exit', resolve));
   child.kill('SIGTERM');
-  await Promise.race([
-    new Promise((resolve) => child.once('exit', resolve)),
-    delay(2_000).then(() => {
-      if (child.exitCode === null) child.kill('SIGKILL');
-    }),
-  ]);
+  await Promise.race([exited, delay(2_000)]);
+  if (child.exitCode === null) {
+    child.kill('SIGKILL');
+    await exited;
+  }
 }

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+
+export async function getFreePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.equal(typeof address, 'object');
+  const port = address.port;
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
+
+export async function waitForHealth(port, child) {
+  const url = `http://127.0.0.1:${port}/health`;
+  let lastError;
+  for (let i = 0; i < 60; i += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`server exited early with code ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+      lastError = new Error(`health returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(100);
+  }
+  throw lastError ?? new Error('server did not become healthy');
+}
+
+export function parseSseJson(body) {
+  const dataLine = body
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('data: '));
+  assert.ok(dataLine, `Missing SSE data line in body: ${body}`);
+  return JSON.parse(dataLine.slice('data: '.length));
+}
+
+export function spawnServer(env) {
+  const child = spawn(process.execPath, ['dist/index.js'], {
+    env: {
+      ...process.env,
+      MCP_DELEGATED_CREDENTIAL_SECRET:
+        'test-mcp-delegated-credential-secret-32',
+      ...env,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  child.stderr.setEncoding('utf8');
+  child.stdout.setEncoding('utf8');
+  return child;
+}
+
+export async function stopChild(child) {
+  if (child.exitCode !== null) return;
+  child.kill('SIGTERM');
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    delay(2_000).then(() => {
+      if (child.exitCode === null) child.kill('SIGKILL');
+    }),
+  ]);
+}

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
-import net from 'node:net';
 import test from 'node:test';
 import { setTimeout as delay } from 'node:timers/promises';
 import { assertAgentMetadataPolicy } from '../scripts/agent-metadata-policy.mjs';
+import {
+  getFreePort,
+  parseSseJson,
+  spawnServer,
+  stopChild,
+  waitForHealth,
+} from './helpers.mjs';
 
 // The fixed contract of the search surface. Nothing outside this set may ever
 // appear on its tools/list or be callable through it.
@@ -37,72 +42,6 @@ const SEARCH_ENDPOINT = '/v2/mcp-search';
 const SEARCH_RESOURCE = 'https://mcp.firecrawl.dev/v2/mcp-search';
 const INVALID_API_KEY_MESSAGE =
   'The Firecrawl API key is invalid or revoked.\nFix: Replace the key on the existing Firecrawl MCP server, then start a new session. Get an API key at https://www.firecrawl.dev/app/api-keys';
-
-async function getFreePort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const { port } = server.address();
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-  return port;
-}
-
-async function waitForHealth(port, child) {
-  const url = `http://127.0.0.1:${port}/health`;
-  let lastError;
-  for (let i = 0; i < 60; i += 1) {
-    if (child.exitCode !== null) {
-      throw new Error(`server exited early with code ${child.exitCode}`);
-    }
-    try {
-      const response = await fetch(url);
-      if (response.ok) return response;
-      lastError = new Error(`health returned ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await delay(100);
-  }
-  throw lastError ?? new Error('server did not become healthy');
-}
-
-function parseSseJson(body) {
-  const dataLine = body
-    .split(/\r?\n/)
-    .find((line) => line.startsWith('data: '));
-  assert.ok(dataLine, `Missing SSE data line in body: ${body}`);
-  return JSON.parse(dataLine.slice('data: '.length));
-}
-
-function spawnServer(env) {
-  const child = spawn(process.execPath, ['dist/index.js'], {
-    env: {
-      ...process.env,
-      MCP_DELEGATED_CREDENTIAL_SECRET:
-        'test-mcp-delegated-credential-secret-32',
-      ...env,
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  child.stderr.setEncoding('utf8');
-  child.stdout.setEncoding('utf8');
-  return child;
-}
-
-async function stopChild(child) {
-  if (child.exitCode !== null) return;
-  child.kill('SIGTERM');
-  await Promise.race([
-    new Promise((resolve) => child.once('exit', resolve)),
-    delay(2_000).then(() => {
-      if (child.exitCode === null) child.kill('SIGKILL');
-    }),
-  ]);
-}
 
 // Fake origin standing in for both the Firecrawl API (/v2/search) and the OAuth
 // issuer (/api/oauth/introspect). Introspection echoes a configurable audience

--- a/tests/mcp-search-profile.test.mjs
+++ b/tests/mcp-search-profile.test.mjs
@@ -717,6 +717,10 @@ test('primary search profile uses the strict marketplace search tool, not the fu
   assert.ok(search, 'primary profile must register firecrawl_search');
   assert.doesNotMatch(JSON.stringify(search.inputSchema), /scrapeOptions/);
   assert.doesNotMatch(search.description ?? '', /search_feedback|refund/i);
+  assert.match(
+    search.description ?? '',
+    /categories: \["research"\].*research-affiliated websites.*`firecrawl_research_\*` tools are a separate surface.*PubMed, bioRxiv, medRxiv.*arXiv/is
+  );
 
   const response = await jsonRpc(port, SEARCH_ENDPOINT, {
     id: 13,

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1360,6 +1360,63 @@ test('crawl bounding preserves the upstream continuation and small responses', a
   });
 });
 
+test('crawl continuation pages are bounded and resumable mid-page', async (t) => {
+  const next = '/v2/crawl/job-big?cursor=page-2';
+  const pageDocuments = Array.from({ length: 30 }, (_, index) => ({
+    url: `https://example.com/page2/${index + 1}`,
+    markdown: `page2 document ${index + 1}`,
+  }));
+  const backend = await startFakeFirecrawlBackend({
+    crawlResponses: {
+      '/v2/crawl/job-big': {
+        status: 'completed',
+        completed: 31,
+        total: 31,
+        next,
+        data: [{ url: 'https://example.com/1', markdown: 'first page document' }],
+      },
+      [next]: { success: true, next: null, data: pageDocuments },
+    },
+  });
+  t.after(() => backend.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: backend.url,
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-crawl-page-bounds', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const firstResult = await client.request('tools/call', {
+    arguments: { id: 'job-big', next },
+    name: 'firecrawl_check_crawl_status',
+  });
+  const first = JSON.parse(firstResult.content[0].text);
+  assert.equal(first.data.length, 25);
+  assert.equal(first._firecrawl.truncated, true);
+  assert.equal(first._firecrawl.next_offset, 25);
+  assert.equal(first._firecrawl.next, next);
+  assert.match(
+    first._firecrawl.message,
+    /firecrawl_check_crawl_status.*id: "job-big".*next:.*offset: 25/is
+  );
+
+  const secondResult = await client.request('tools/call', {
+    arguments: { id: 'job-big', next, offset: 25 },
+    name: 'firecrawl_check_crawl_status',
+  });
+  const second = JSON.parse(secondResult.content[0].text);
+  assert.equal(second.data.length, 5);
+  assert.equal(second.data[0].markdown, 'page2 document 26');
+  assert.notEqual(second._firecrawl?.truncated, true);
+});
+
 test('crawl bounding exposes offset continuation for a single upstream page', async (t) => {
   const documents = Array.from({ length: 50 }, (_, index) => ({
     url: `https://example.com/${index + 1}`,
@@ -1395,7 +1452,7 @@ test('crawl bounding exposes offset continuation for a single upstream page', as
   const statusTool = tools.tools.find(
     (tool) => tool.name === 'firecrawl_check_crawl_status'
   );
-  assert.match(statusTool.inputSchema.properties.offset.description, /next.*precedence/i);
+  assert.match(statusTool.inputSchema.properties.offset.description, /offset.*prior guidance/i);
 
   const firstResult = await client.request('tools/call', {
     arguments: { id: 'job-single-page' },

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -464,6 +464,49 @@ test('tool failures carry structured codes instead of silent success', async (t)
   }
 });
 
+test('threat-protection policy blocks are permanent, not retryable', async (t) => {
+  // apps/api emits a second domain-policy 403 besides the blocklist message:
+  // "blocked by your organization's threat protection policy". It is just as
+  // permanent, so it must not be classified as a retryable upstream failure.
+  const backend = await startFakeFirecrawlBackend({
+    scrapeResponse: {
+      status: 403,
+      body: {
+        success: false,
+        error:
+          "This URL (https://example.com/) is blocked by your organization's threat protection policy (rule: deny-example). If you believe this is a mistake, contact your organization administrator to adjust the policy (e.g. whitelist the domain).",
+      },
+    },
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    id: 'threat-protection',
+    headers: { 'x-api-key': 'fc-test' },
+    params: {
+      arguments: { url: 'https://example.com/' },
+      name: 'firecrawl_scrape',
+    },
+  });
+  const result = parseSseJson(await response.text()).result;
+  assert.equal(result.isError, true);
+  assert.equal(result.structuredContent.code, 'UNSUPPORTED_SITE');
+  assert.equal(result.structuredContent.retryable, false);
+  assert.doesNotMatch(result.structuredContent.message, /\bretry\b/i);
+});
+
 test('parse, interact, and monitor failures use the shared structured boundary', async (t) => {
   const backend = await startFakeFirecrawlBackend({
     monitorResponse: { status: 503, body: { success: false, error: 'monitor unavailable' } },

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1298,6 +1298,7 @@ test('crawl bounding preserves the upstream continuation and small responses', a
   const first = JSON.parse(firstResult.content[0].text);
   assert.equal(first.next, next);
   assert.equal(first._firecrawl.truncated, true);
+  assert.match(first._firecrawl.message, /shown documents 1-1.*3 total/i);
   assert.match(first._firecrawl.message, /firecrawl_check_crawl_status.*next/i);
   assert.deepEqual(
     backend.requests.filter((request) => request.method === 'GET').map((request) => request.url),
@@ -1343,6 +1344,72 @@ test('crawl bounding preserves the upstream continuation and small responses', a
     next: null,
     data: [{ url: 'https://example.com/small', markdown: 'small page' }],
   });
+});
+
+test('crawl bounding exposes offset continuation for a single upstream page', async (t) => {
+  const documents = Array.from({ length: 50 }, (_, index) => ({
+    url: `https://example.com/${index + 1}`,
+    markdown: `document ${index + 1}`,
+  }));
+  const backend = await startFakeFirecrawlBackend({
+    crawlResponses: {
+      '/v2/crawl/job-single-page': {
+        status: 'completed',
+        completed: 50,
+        total: 50,
+        next: null,
+        data: documents,
+      },
+    },
+  });
+  t.after(() => backend.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: backend.url,
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-crawl-offset', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const tools = await client.request('tools/list');
+  const statusTool = tools.tools.find(
+    (tool) => tool.name === 'firecrawl_check_crawl_status'
+  );
+  assert.match(statusTool.inputSchema.properties.offset.description, /next.*precedence/i);
+
+  const firstResult = await client.request('tools/call', {
+    arguments: { id: 'job-single-page' },
+    name: 'firecrawl_check_crawl_status',
+  });
+  const first = JSON.parse(firstResult.content[0].text);
+  assert.equal(first.data.length, 25);
+  assert.equal(first.data[0].markdown, 'document 1');
+  assert.equal(first.data[24].markdown, 'document 25');
+  assert.equal(first._firecrawl.truncated, true);
+  assert.equal(first._firecrawl.next_offset, 25);
+  assert.match(first._firecrawl.message, /shown documents 1-25 of 50/i);
+  assert.match(
+    first._firecrawl.message,
+    /firecrawl_check_crawl_status.*id: "job-single-page".*offset: 25/i
+  );
+
+  const secondResult = await client.request('tools/call', {
+    arguments: { id: 'job-single-page', offset: 25 },
+    name: 'firecrawl_check_crawl_status',
+  });
+  const second = JSON.parse(secondResult.content[0].text);
+  assert.equal(second.data.length, 25);
+  assert.equal(second.data[0].markdown, 'document 26');
+  assert.equal(second.data[24].markdown, 'document 50');
+  assert.equal(second._firecrawl.truncated, false);
+  assert.match(second._firecrawl.message, /shown documents 26-50 of 50/i);
+  assert.match(second._firecrawl.message, /all available documents have been returned/i);
 });
 
 test('crawl continuation accepts a path-prefixed API base', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -457,6 +457,10 @@ test('tool failures carry structured codes instead of silent success', async (t)
       assert.equal(result.structuredContent.retryable, false, name);
       assert.doesNotMatch(result.structuredContent.message, /\bretry\b/i, name);
     }
+    if (expectedCode === 'UPSTREAM_REQUEST_FAILED') {
+      // Status checks are read-only; unclassified failures stay retryable.
+      assert.equal(result.structuredContent.retryable, true, name);
+    }
   }
 });
 
@@ -493,6 +497,10 @@ test('parse, interact, and monitor failures use the shared structured boundary',
     ],
     ['firecrawl_search', { query: 'plan-gated feature' }, 'UPSTREAM_REQUEST_FAILED'],
   ]) {
+    // Non-idempotent tools must not advertise retryable on unclassified
+    // upstream failures: the action may already have taken effect (a created
+    // monitor, a submitted form) and an obedient agent would repeat it.
+    const expectedRetryable = name === 'firecrawl_search';
     const response = await httpToolCall(port, {
       id: `structured-${name}`,
       headers: { 'x-api-key': 'fc-test' },
@@ -502,6 +510,9 @@ test('parse, interact, and monitor failures use the shared structured boundary',
     assert.equal(result.isError, true, name);
     assert.equal(result.structuredContent.code, expectedCode, name);
     assert.equal(typeof result.structuredContent.original_error, 'string', name);
+    if (expectedCode === 'UPSTREAM_REQUEST_FAILED') {
+      assert.equal(result.structuredContent.retryable, expectedRetryable, name);
+    }
   }
 });
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -514,6 +514,7 @@ test('parse, interact, and monitor failures use the shared structured boundary',
   const backend = await startFakeFirecrawlBackend({
     monitorResponse: { status: 503, body: { success: false, error: 'monitor unavailable' } },
     scrapeResponse: { status: 200, body: { success: true, data: { markdown: '# page' } } },
+    searchResponse: { status: 402, body: { error: 'This feature requires a paid plan.' } },
   });
   t.after(() => backend.close());
   const port = await getFreePort();
@@ -540,6 +541,7 @@ test('parse, interact, and monitor failures use the shared structured boundary',
       { page: 'https://example.com/', goal: 'Track title changes' },
       'UPSTREAM_REQUEST_FAILED',
     ],
+    ['firecrawl_search', { query: 'plan-gated feature' }, 'UPSTREAM_REQUEST_FAILED'],
   ]) {
     const response = await httpToolCall(port, {
       id: `structured-${name}`,
@@ -557,7 +559,14 @@ test('empty and likely-blocked results carry in-band Firecrawl notices', async (
   const backend = await startFakeFirecrawlBackend({
     scrapeResponse: {
       status: 200,
-      body: { success: true, data: { markdown: '', metadata: { statusCode: 403 } } },
+      body: {
+        success: true,
+        data: {
+          markdown: '',
+          metadata: { statusCode: 403 },
+          warning: `blocked ${'x'.repeat(20_000)}`,
+        },
+      },
     },
     searchResponse: { status: 200, body: { success: true, data: { web: [] } } },
   });
@@ -576,7 +585,11 @@ test('empty and likely-blocked results carry in-band Firecrawl notices', async (
   await waitForHealth(port, child);
 
   for (const [name, arguments_, expectedCode] of [
-    ['firecrawl_scrape', { url: 'https://example.com/' }, 'LIKELY_BLOCKED'],
+    [
+      'firecrawl_scrape',
+      { url: 'https://example.com/', response_format: 'concise' },
+      'LIKELY_BLOCKED',
+    ],
     ['firecrawl_search', { query: 'no matching result' }, 'EMPTY_RESULT'],
   ]) {
     const response = await httpToolCall(port, {
@@ -588,9 +601,54 @@ test('empty and likely-blocked results carry in-band Firecrawl notices', async (
     assert.notEqual(result.isError, true, name);
     const payload = JSON.parse(result.content[0].text);
     assert.equal(payload._firecrawl.code, expectedCode, name);
-    assert.match(payload._firecrawl.message, /empty|blocked/i, name);
     assert.ok(Array.isArray(payload._firecrawl.next_actions), name);
+    if (name === 'firecrawl_scrape') {
+      assert.equal(payload._firecrawl.truncated, true);
+    } else {
+      assert.match(payload._firecrawl.message, /empty/i, name);
+    }
   }
+});
+
+test('non-empty scrape content is not flagged as likely blocked', async (t) => {
+  const backend = await startFakeFirecrawlBackend({
+    scrapeResponse: {
+      status: 200,
+      body: {
+        success: true,
+        data: {
+          markdown: `# Usable page\n\n${'content '.repeat(100)}`,
+          metadata: { statusCode: 403 },
+        },
+      },
+    },
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  const response = await httpToolCall(port, {
+    id: 'non-empty-block-signal',
+    headers: { 'x-api-key': 'fc-test' },
+    params: {
+      arguments: { url: 'https://example.com/' },
+      name: 'firecrawl_scrape',
+    },
+  });
+  const result = parseSseJson(await response.text()).result;
+  assert.notEqual(result.isError, true);
+  const payload = JSON.parse(result.content[0].text);
+  assert.equal(payload._firecrawl, undefined);
 });
 
 test('HTTP cloud keyless transport preserves app challenge without advertising OAuth', async (t) => {
@@ -1073,7 +1131,7 @@ test('payload-heavy responses are bounded with explicit retrieval guidance', asy
         data: {
           web: [
             {
-              title: 'Large result',
+              title: `${'a'.repeat(1_999)}😀 trailing`,
               url: 'https://example.com/large',
               markdown: largeMarkdown,
               html: `<main>${largeMarkdown}</main>`,
@@ -1141,6 +1199,8 @@ test('payload-heavy responses are bounded with explicit retrieval guidance', asy
   assert.match(concise._firecrawl.message, /response_format.*detailed/i);
   assert.equal(concise.data.web[0].rawHtml, undefined);
   assert.equal(concise.data.web[0].screenshot, undefined);
+  const titlePrefix = concise.data.web[0].title.split('\n[truncated')[0];
+  assert.equal(titlePrefix.endsWith('\ud83d'), false);
 
   const requests = backend.requests.filter(
     (request) => request.method === 'POST' && request.url === '/v2/search'
@@ -1148,6 +1208,47 @@ test('payload-heavy responses are bounded with explicit retrieval guidance', asy
   assert.equal(requests.length, 2);
   assert.equal(requests[0].body.response_format, undefined);
   assert.equal(requests[1].body.response_format, undefined);
+});
+
+test('many medium search results respect the total response cap', async (t) => {
+  const backend = await startFakeFirecrawlBackend({
+    searchResponse: {
+      status: 200,
+      body: {
+        success: true,
+        data: {
+          web: Array.from({ length: 50 }, (_, index) => ({
+            title: `Result ${index}`,
+            url: `https://example.com/${index}`,
+            markdown: 'medium content '.repeat(700),
+          })),
+        },
+      },
+    },
+  });
+  t.after(() => backend.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: backend.url,
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-total-output-cap', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const result = await client.request('tools/call', {
+    arguments: { query: 'many medium results' },
+    name: 'firecrawl_search',
+  });
+  const text = result.content[0].text;
+  const payload = JSON.parse(text);
+  assert.ok(text.length <= 64_000, `detailed response was ${text.length} chars`);
+  assert.equal(payload._firecrawl.truncated, true);
 });
 
 test('crawl bounding preserves the upstream continuation and small responses', async (t) => {
@@ -1203,6 +1304,25 @@ test('crawl bounding preserves the upstream continuation and small responses', a
     ['/v2/crawl/job-1']
   );
 
+  for (const rejectedNext of [
+    'https://evil.example/v2/crawl/job-1?cursor=stolen',
+    '/v2/crawl/other-job?cursor=stolen',
+  ]) {
+    const rejectedResult = await client.request('tools/call', {
+      arguments: { id: 'job-1', next: rejectedNext },
+      name: 'firecrawl_check_crawl_status',
+    });
+    assert.equal(rejectedResult.isError, true);
+    assert.equal(rejectedResult.structuredContent.code, 'INVALID_REQUEST');
+  }
+
+  const emptyIdResult = await client.request('tools/call', {
+    arguments: { id: '', next: '/v2/crawl/?cursor=invalid' },
+    name: 'firecrawl_check_crawl_status',
+  });
+  assert.equal(emptyIdResult.isError, true);
+  assert.equal(emptyIdResult.structuredContent.code, 'INVALID_REQUEST');
+
   const continuationResult = await client.request('tools/call', {
     arguments: { id: 'job-1', next },
     name: 'firecrawl_check_crawl_status',
@@ -1223,6 +1343,46 @@ test('crawl bounding preserves the upstream continuation and small responses', a
     next: null,
     data: [{ url: 'https://example.com/small', markdown: 'small page' }],
   });
+});
+
+test('crawl continuation accepts a path-prefixed API base', async (t) => {
+  const next = '/firecrawl/v2/crawl/job-prefix?cursor=next-page';
+  const backend = await startFakeFirecrawlBackend({
+    crawlResponses: {
+      [next]: {
+        status: 'completed',
+        completed: 2,
+        total: 2,
+        next: null,
+        data: [{ url: 'https://example.com/2', markdown: 'second page' }],
+      },
+    },
+  });
+  t.after(() => backend.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: `${backend.url}/firecrawl`,
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-prefixed-continuation', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const result = await client.request('tools/call', {
+    arguments: { id: 'job-prefix', next },
+    name: 'firecrawl_check_crawl_status',
+  });
+  assert.notEqual(
+    result.isError,
+    true,
+    JSON.stringify({ result, requests: backend.requests })
+  );
+  assert.equal(JSON.parse(result.content[0].text).data[0].markdown, 'second page');
 });
 
 test('local keyless stdio lists exactly its callable tools', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1,53 +1,15 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
-import net from 'node:net';
 import test from 'node:test';
 import { setTimeout as delay } from 'node:timers/promises';
 import { assertAgentMetadataPolicy } from '../scripts/agent-metadata-policy.mjs';
-
-async function getFreePort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const address = server.address();
-  assert.equal(typeof address, 'object');
-  const port = address.port;
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-  return port;
-}
-
-async function waitForHealth(port, child) {
-  const url = `http://127.0.0.1:${port}/health`;
-  let lastError;
-  for (let i = 0; i < 60; i += 1) {
-    if (child.exitCode !== null) {
-      throw new Error(`server exited early with code ${child.exitCode}`);
-    }
-    try {
-      const response = await fetch(url);
-      if (response.ok) return response;
-      lastError = new Error(`health returned ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await delay(100);
-  }
-  throw lastError ?? new Error('server did not become healthy');
-}
-
-
-function parseSseJson(body) {
-  const dataLine = body
-    .split(/\r?\n/)
-    .find((line) => line.startsWith('data: '));
-  assert.ok(dataLine, `Missing SSE data line in body: ${body}`);
-  return JSON.parse(dataLine.slice('data: '.length));
-}
+import {
+  getFreePort,
+  parseSseJson,
+  spawnServer,
+  stopChild,
+  waitForHealth,
+} from './helpers.mjs';
 
 function assertServerGeneratedRequestId(payload, untrustedValues = []) {
   assert.match(
@@ -99,32 +61,6 @@ function assertKeylessAccountRecovery(
     result.structuredContent,
     untrustedRequestIds
   );
-}
-
-function spawnServer(env) {
-  const child = spawn(process.execPath, ['dist/index.js'], {
-    env: {
-      ...process.env,
-      MCP_DELEGATED_CREDENTIAL_SECRET:
-        'test-mcp-delegated-credential-secret-32',
-      ...env,
-    },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  child.stderr.setEncoding('utf8');
-  child.stdout.setEncoding('utf8');
-  return child;
-}
-
-async function stopChild(child) {
-  if (child.exitCode !== null) return;
-  child.kill('SIGTERM');
-  await Promise.race([
-    new Promise((resolve) => child.once('exit', resolve)),
-    delay(2_000).then(() => {
-      if (child.exitCode === null) child.kill('SIGKILL');
-    }),
-  ]);
 }
 
 async function startFakeFirecrawlApi() {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -280,6 +280,7 @@ async function startFakeFirecrawlBackend(options = {}) {
     introspectionHandler,
     introspectionMetadata = {},
     keylessEligible = false,
+    crawlResponses = {},
     keylessEligibilityResponse,
     searchResponse,
   } = options;
@@ -357,6 +358,12 @@ async function startFakeFirecrawlBackend(options = {}) {
           success: true,
         })
       );
+      return;
+    }
+
+    if (req.method === 'GET' && crawlResponses[req.url]) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(crawlResponses[req.url]));
       return;
     }
 
@@ -821,6 +828,168 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   ].join('\n');
   assertAgentMetadataPolicy(renderedLanguage, assert);
   assert.equal(stderr.includes('TypeError'), false, stderr);
+});
+
+test('payload-heavy responses are bounded with explicit retrieval guidance', async (t) => {
+  const largeMarkdown = 'content '.repeat(30_000);
+  const backend = await startFakeFirecrawlBackend({
+    searchResponse: {
+      status: 200,
+      body: {
+        success: true,
+        data: {
+          web: [
+            {
+              title: 'Large result',
+              url: 'https://example.com/large',
+              markdown: largeMarkdown,
+              html: `<main>${largeMarkdown}</main>`,
+              rawHtml: `<html>${largeMarkdown}</html>`,
+              screenshot: `data:image/png;base64,${'A'.repeat(20_000)}`,
+            },
+          ],
+        },
+      },
+    },
+  });
+  t.after(() => backend.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: backend.url,
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-output-bounds', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const tools = await client.request('tools/list');
+  for (const name of [
+    'firecrawl_scrape',
+    'firecrawl_search',
+    'firecrawl_crawl',
+    'firecrawl_check_crawl_status',
+    'firecrawl_parse',
+    'firecrawl_agent_status',
+    'firecrawl_interact',
+  ]) {
+    const tool = tools.tools.find((candidate) => candidate.name === name);
+    assert.ok(tool, `${name} must be listed`);
+    assert.deepEqual(tool.inputSchema.properties.response_format.enum, [
+      'concise',
+      'detailed',
+    ]);
+    assert.equal(tool.inputSchema.properties.response_format.default, 'detailed');
+  }
+
+  const detailedResult = await client.request('tools/call', {
+    arguments: { query: 'large result' },
+    name: 'firecrawl_search',
+  });
+  const detailedText = detailedResult.content[0].text;
+  const detailed = JSON.parse(detailedText);
+  assert.ok(detailedText.length <= 65_000, `detailed response was ${detailedText.length} chars`);
+  assert.equal(detailed._firecrawl.truncated, true);
+  assert.match(detailed._firecrawl.message, /narrower query|lower limit/i);
+
+  const conciseResult = await client.request('tools/call', {
+    arguments: { query: 'large result', response_format: 'concise' },
+    name: 'firecrawl_search',
+  });
+  const conciseText = conciseResult.content[0].text;
+  const concise = JSON.parse(conciseText);
+  assert.ok(conciseText.length <= 13_000, `concise response was ${conciseText.length} chars`);
+  assert.ok(conciseText.length < detailedText.length);
+  assert.equal(concise._firecrawl.truncated, true);
+  assert.match(concise._firecrawl.message, /response_format.*detailed/i);
+  assert.equal(concise.data.web[0].rawHtml, undefined);
+  assert.equal(concise.data.web[0].screenshot, undefined);
+
+  const requests = backend.requests.filter(
+    (request) => request.method === 'POST' && request.url === '/v2/search'
+  );
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].body.response_format, undefined);
+  assert.equal(requests[1].body.response_format, undefined);
+});
+
+test('crawl bounding preserves the upstream continuation and small responses', async (t) => {
+  const next = '/v2/crawl/job-1?cursor=next-page';
+  const backend = await startFakeFirecrawlBackend({
+    crawlResponses: {
+      '/v2/crawl/job-1': {
+        status: 'completed',
+        completed: 3,
+        total: 3,
+        next,
+        data: [{ url: 'https://example.com/1', markdown: 'x'.repeat(70_000) }],
+      },
+      [next]: {
+        success: true,
+        next: null,
+        data: [{ url: 'https://example.com/2', markdown: 'small page' }],
+      },
+      '/v2/crawl/job-small': {
+        status: 'completed',
+        completed: 1,
+        total: 1,
+        next: null,
+        data: [{ url: 'https://example.com/small', markdown: 'small page' }],
+      },
+    },
+  });
+  t.after(() => backend.close());
+
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: backend.url,
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-crawl-bounds', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+
+  const firstResult = await client.request('tools/call', {
+    arguments: { id: 'job-1' },
+    name: 'firecrawl_check_crawl_status',
+  });
+  const first = JSON.parse(firstResult.content[0].text);
+  assert.equal(first.next, next);
+  assert.equal(first._firecrawl.truncated, true);
+  assert.match(first._firecrawl.message, /firecrawl_check_crawl_status.*next/i);
+  assert.deepEqual(
+    backend.requests.filter((request) => request.method === 'GET').map((request) => request.url),
+    ['/v2/crawl/job-1']
+  );
+
+  const continuationResult = await client.request('tools/call', {
+    arguments: { id: 'job-1', next },
+    name: 'firecrawl_check_crawl_status',
+  });
+  const continuation = JSON.parse(continuationResult.content[0].text);
+  assert.equal(continuation.data[0].markdown, 'small page');
+  assert.equal(continuation.next, null);
+
+  const smallResult = await client.request('tools/call', {
+    arguments: { id: 'job-small' },
+    name: 'firecrawl_check_crawl_status',
+  });
+  assert.deepEqual(JSON.parse(smallResult.content[0].text), {
+    id: 'job-small',
+    status: 'completed',
+    completed: 1,
+    total: 1,
+    next: null,
+    data: [{ url: 'https://example.com/small', markdown: 'small page' }],
+  });
 });
 
 test('local keyless stdio omits feedback tools and qualifies search-feedback IDs as authenticated-only', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -319,6 +319,15 @@ async function startFakeFirecrawlBackend(options = {}) {
       return;
     }
 
+    if (
+      req.method === 'POST' &&
+      req.url === '/v2/monitor/mon-1/run' &&
+      monitorResponse
+    ) {
+      res.writeHead(monitorResponse.status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(monitorResponse.body));
+      return;
+    }
     if (req.method === 'POST' && req.url === '/v2/monitor' && monitorResponse) {
       res.writeHead(monitorResponse.status, { 'content-type': 'application/json' });
       res.end(JSON.stringify(monitorResponse.body));
@@ -532,16 +541,18 @@ test('SDK status and code classify rate limits and opaque timeouts', async (t) =
 });
 
 test('threat-protection policy blocks are permanent, not retryable', async (t) => {
-  // apps/api emits a second domain-policy 403 besides the blocklist message:
-  // "blocked by your organization's threat protection policy". It is just as
-  // permanent, so it must not be classified as a retryable upstream failure.
+  // apps/api emits a second domain-policy 403 besides the blocklist message.
+  // Its stable API contract is code: "unsafe_domain_blocked" (the message text
+  // can be reworded), so the body here deliberately uses phrasing the message
+  // regex would NOT match - classification must come from the code.
   const backend = await startFakeFirecrawlBackend({
     scrapeResponse: {
       status: 403,
       body: {
         success: false,
+        code: 'unsafe_domain_blocked',
         error:
-          "This URL (https://example.com/) is blocked by your organization's threat protection policy (rule: deny-example). If you believe this is a mistake, contact your organization administrator to adjust the policy (e.g. whitelist the domain).",
+          'Domain example.com is denied by org policy rule deny-example. Contact your administrator.',
       },
     },
   });
@@ -605,11 +616,17 @@ test('parse, interact, and monitor failures use the shared structured boundary',
       { page: 'https://example.com/', goal: 'Track title changes' },
       'UPSTREAM_REQUEST_FAILED',
     ],
+    [
+      'firecrawl_monitor_run',
+      { id: 'mon-1' },
+      'UPSTREAM_REQUEST_FAILED',
+    ],
     ['firecrawl_search', { query: 'plan-gated feature' }, 'UPSTREAM_REQUEST_FAILED'],
   ]) {
     // Non-idempotent tools must not advertise retryable on unclassified
     // upstream failures: the action may already have taken effect (a created
-    // monitor, a submitted form) and an obedient agent would repeat it.
+    // monitor, a queued run, a submitted form) and an obedient agent would
+    // repeat it.
     const expectedRetryable = name === 'firecrawl_search';
     const response = await httpToolCall(port, {
       id: `structured-${name}`,

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -903,6 +903,7 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.ok(toolNames.includes('firecrawl_scrape'));
   assert.ok(toolNames.includes('firecrawl_search'));
   assert.ok(toolNames.includes('firecrawl_parse'));
+  assert.equal(toolNames.length, 26);
   assert.equal(toolNames.includes('firecrawl_extract'), false);
 
   const deprecatedExtract = await client.request('tools/call', {
@@ -1174,7 +1175,7 @@ test('crawl bounding preserves the upstream continuation and small responses', a
   });
 });
 
-test('local keyless stdio omits feedback tools and qualifies search-feedback IDs as authenticated-only', async (t) => {
+test('local keyless stdio lists exactly its callable tools', async (t) => {
   const child = spawnServer({
     FIRECRAWL_API_KEY: '',
     FIRECRAWL_API_URL: '',
@@ -1183,22 +1184,33 @@ test('local keyless stdio omits feedback tools and qualifies search-feedback IDs
   t.after(() => stopChild(child));
 
   const client = new StdioMcpClient(child);
-  await client.request('initialize', {
+  const init = await client.request('initialize', {
     capabilities: {},
     clientInfo: { name: 'firecrawl-local-keyless', version: '0.0.0' },
     protocolVersion: '2025-06-18',
   });
   client.notify('notifications/initialized');
   const tools = await client.request('tools/list');
-  const toolNames = tools.tools.map((tool) => tool.name);
-  assert.equal(toolNames.includes('firecrawl_search_feedback'), false);
-  assert.equal(toolNames.includes('firecrawl_feedback'), false);
+  assert.deepEqual(
+    tools.tools.map((tool) => tool.name).sort(),
+    ['firecrawl_scrape', 'firecrawl_search']
+  );
+  assert.match(init.instructions, /exposes Search and Scrape with usage limits/i);
+  assert.doesNotMatch(init.instructions, /exposes Search, Scrape, and Parse/i);
+
   const search = tools.tools.find((tool) => tool.name === 'firecrawl_search');
   assert.ok(search);
   assert.match(
     search.description,
     /authenticated responses can include an `id` for optional search feedback/i
   );
+
+  const hiddenMap = await client.request('tools/call', {
+    arguments: { url: 'https://example.com' },
+    name: 'firecrawl_map',
+  });
+  assert.equal(hiddenMap.isError, true);
+  assert.equal(hiddenMap.structuredContent.code, 'AUTH_REQUIRED');
 });
 
 test('monitor create gives queries precedence over page targets', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -923,6 +923,14 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   );
 
   const byName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+  const descriptionCharacters = tools.tools.reduce(
+    (total, tool) => total + (tool.description?.trim().length ?? 0),
+    0
+  );
+  assert.ok(
+    descriptionCharacters <= 6_000,
+    `tool descriptions exceed lean-copy budget: ${descriptionCharacters}`
+  );
   const properties = tools.tools.flatMap((tool) =>
     Object.values(tool.inputSchema.properties ?? {})
   );

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -467,6 +467,14 @@ test('tool failures carry structured codes instead of silent success', async (t)
   const backend = await startFakeFirecrawlBackend({
     crawlStartResponse: { status: 200, body: { success: false, error: 'crawl rejected' } },
     feedbackResponse: { status: 422, body: { error: 'feedback rejected', feedbackErrorCode: 'invalid_job' } },
+    scrapeResponse: {
+      status: 403,
+      body: {
+        success: false,
+        error:
+          'We apologize for the inconvenience but we do not support this site. If you are part of an enterprise and want to have a further conversation about this, please fill out our intake form here: https://example.com/intake',
+      },
+    },
   });
   t.after(() => backend.close());
   const port = await getFreePort();
@@ -490,6 +498,7 @@ test('tool failures carry structured codes instead of silent success', async (t)
       'FEEDBACK_REJECTED',
     ],
     ['firecrawl_check_crawl_status', { id: 'bogus-job' }, 'UPSTREAM_REQUEST_FAILED'],
+    ['firecrawl_scrape', { url: 'https://www.linkedin.com/feed/' }, 'UNSUPPORTED_SITE'],
     [
       'firecrawl_search',
       { query: 'firecrawl', includeDomains: ['example.com'], excludeDomains: ['example.com'] },
@@ -507,6 +516,11 @@ test('tool failures carry structured codes instead of silent success', async (t)
     assert.equal(result.content[0].text, result.structuredContent.message, name);
     assert.match(result.structuredContent.message, /retry|check|verify|use/i, name);
     assert.equal(typeof result.structuredContent.original_error, 'string', name);
+    if (expectedCode === 'UNSUPPORTED_SITE') {
+      // Domain-policy rejections are permanent; retrying the same URL cannot succeed.
+      assert.equal(result.structuredContent.retryable, false, name);
+      assert.doesNotMatch(result.structuredContent.message, /\bretry\b/i, name);
+    }
   }
 });
 

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -408,6 +408,35 @@ async function httpToolCall(port, { endpoint = '/v2/mcp', id, headers, params })
   });
 }
 
+async function startHostedCloudServer(t, backend) {
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+  return port;
+}
+
+async function startStdioClient(t, env, clientName) {
+  const child = spawnServer({ FIRECRAWL_API_KEY: 'fc-test', ...env });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: clientName, version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+  return client;
+}
+
 test('tool failures carry structured codes instead of silent success', async (t) => {
   const backend = await startFakeFirecrawlBackend({
     crawlStartResponse: { status: 200, body: { success: false, error: 'crawl rejected' } },
@@ -422,18 +451,7 @@ test('tool failures carry structured codes instead of silent success', async (t)
     },
   });
   t.after(() => backend.close());
-  const port = await getFreePort();
-  const child = spawnServer({
-    CLOUD_SERVICE: 'true',
-    FASTMCP_ENDPOINT: '/v2/mcp',
-    FIRECRAWL_API_URL: backend.url,
-    FIRECRAWL_OAUTH_ISSUER: backend.url,
-    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
-    HTTP_STREAMABLE_SERVER: 'true',
-    PORT: String(port),
-  });
-  t.after(() => stopChild(child));
-  await waitForHealth(port, child);
+  const port = await startHostedCloudServer(t, backend);
 
   for (const [name, arguments_, expectedCode] of [
     ['firecrawl_crawl', { url: 'https://example.com/' }, 'CRAWL_START_FAILED'],
@@ -508,18 +526,7 @@ test('SDK status and code classify rate limits and opaque timeouts', async (t) =
     await t.test(testCase.name, async (t) => {
       const backend = await startFakeFirecrawlBackend(testCase.backend);
       t.after(() => backend.close());
-      const port = await getFreePort();
-      const child = spawnServer({
-        CLOUD_SERVICE: 'true',
-        FASTMCP_ENDPOINT: '/v2/mcp',
-        FIRECRAWL_API_URL: backend.url,
-        FIRECRAWL_OAUTH_ISSUER: backend.url,
-        FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
-        HTTP_STREAMABLE_SERVER: 'true',
-        PORT: String(port),
-      });
-      t.after(() => stopChild(child));
-      await waitForHealth(port, child);
+      const port = await startHostedCloudServer(t, backend);
 
       const response = await httpToolCall(port, {
         id: `sdk-error-${testCase.name}`,
@@ -557,18 +564,7 @@ test('threat-protection policy blocks are permanent, not retryable', async (t) =
     },
   });
   t.after(() => backend.close());
-  const port = await getFreePort();
-  const child = spawnServer({
-    CLOUD_SERVICE: 'true',
-    FASTMCP_ENDPOINT: '/v2/mcp',
-    FIRECRAWL_API_URL: backend.url,
-    FIRECRAWL_OAUTH_ISSUER: backend.url,
-    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
-    HTTP_STREAMABLE_SERVER: 'true',
-    PORT: String(port),
-  });
-  t.after(() => stopChild(child));
-  await waitForHealth(port, child);
+  const port = await startHostedCloudServer(t, backend);
 
   const response = await httpToolCall(port, {
     id: 'threat-protection',
@@ -592,18 +588,7 @@ test('parse, interact, and monitor failures use the shared structured boundary',
     searchResponse: { status: 402, body: { error: 'This feature requires a paid plan.' } },
   });
   t.after(() => backend.close());
-  const port = await getFreePort();
-  const child = spawnServer({
-    CLOUD_SERVICE: 'true',
-    FASTMCP_ENDPOINT: '/v2/mcp',
-    FIRECRAWL_API_URL: backend.url,
-    FIRECRAWL_OAUTH_ISSUER: backend.url,
-    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
-    HTTP_STREAMABLE_SERVER: 'true',
-    PORT: String(port),
-  });
-  t.after(() => stopChild(child));
-  await waitForHealth(port, child);
+  const port = await startHostedCloudServer(t, backend);
 
   for (const [name, arguments_, expectedCode] of [
     [
@@ -659,18 +644,7 @@ test('empty and likely-blocked results carry in-band Firecrawl notices', async (
     searchResponse: { status: 200, body: { success: true, data: { web: [] } } },
   });
   t.after(() => backend.close());
-  const port = await getFreePort();
-  const child = spawnServer({
-    CLOUD_SERVICE: 'true',
-    FASTMCP_ENDPOINT: '/v2/mcp',
-    FIRECRAWL_API_URL: backend.url,
-    FIRECRAWL_OAUTH_ISSUER: backend.url,
-    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
-    HTTP_STREAMABLE_SERVER: 'true',
-    PORT: String(port),
-  });
-  t.after(() => stopChild(child));
-  await waitForHealth(port, child);
+  const port = await startHostedCloudServer(t, backend);
 
   for (const [name, arguments_, expectedCode] of [
     ['firecrawl_scrape', { url: 'https://example.com/' }, 'LIKELY_BLOCKED'],
@@ -708,18 +682,7 @@ test('non-empty scrape content is not flagged as likely blocked', async (t) => {
     },
   });
   t.after(() => backend.close());
-  const port = await getFreePort();
-  const child = spawnServer({
-    CLOUD_SERVICE: 'true',
-    FASTMCP_ENDPOINT: '/v2/mcp',
-    FIRECRAWL_API_URL: backend.url,
-    FIRECRAWL_OAUTH_ISSUER: backend.url,
-    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
-    HTTP_STREAMABLE_SERVER: 'true',
-    PORT: String(port),
-  });
-  t.after(() => stopChild(child));
-  await waitForHealth(port, child);
+  const port = await startHostedCloudServer(t, backend);
 
   const response = await httpToolCall(port, {
     id: 'non-empty-block-signal',
@@ -1000,18 +963,7 @@ class StdioMcpClient {
 test('local parse missing files return FILE_NOT_FOUND recovery', async (t) => {
   const backend = await startFakeFirecrawlBackend();
   t.after(() => backend.close());
-  const child = spawnServer({
-    FIRECRAWL_API_KEY: 'fc-test',
-    FIRECRAWL_API_URL: backend.url,
-  });
-  t.after(() => stopChild(child));
-  const client = new StdioMcpClient(child);
-  await client.request('initialize', {
-    capabilities: {},
-    clientInfo: { name: 'firecrawl-mcp-smoke', version: '0.0.0' },
-    protocolVersion: '2025-06-18',
-  });
-  client.notify('notifications/initialized');
+  const client = await startStdioClient(t, { FIRECRAWL_API_URL: backend.url }, 'firecrawl-mcp-smoke');
   const result = await client.request('tools/call', {
     arguments: { filePath: '/definitely/missing/firecrawl-cycle2.pdf' },
     name: 'firecrawl_parse',
@@ -1045,7 +997,6 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   assert.ok(toolNames.includes('firecrawl_scrape'));
   assert.ok(toolNames.includes('firecrawl_search'));
   assert.ok(toolNames.includes('firecrawl_parse'));
-  assert.equal(toolNames.length, 26);
   assert.equal(toolNames.includes('firecrawl_extract'), false);
 
   const deprecatedExtract = await client.request('tools/call', {
@@ -1229,18 +1180,7 @@ test('payload-heavy responses are bounded with explicit retrieval guidance', asy
   });
   t.after(() => backend.close());
 
-  const child = spawnServer({
-    FIRECRAWL_API_KEY: 'fc-test',
-    FIRECRAWL_API_URL: backend.url,
-  });
-  t.after(() => stopChild(child));
-  const client = new StdioMcpClient(child);
-  await client.request('initialize', {
-    capabilities: {},
-    clientInfo: { name: 'firecrawl-output-bounds', version: '0.0.0' },
-    protocolVersion: '2025-06-18',
-  });
-  client.notify('notifications/initialized');
+  const client = await startStdioClient(t, { FIRECRAWL_API_URL: backend.url }, 'firecrawl-output-bounds');
 
   const result = await client.request('tools/call', {
     arguments: { query: 'large result' },
@@ -1278,18 +1218,7 @@ test('many medium search results respect the total response cap', async (t) => {
   });
   t.after(() => backend.close());
 
-  const child = spawnServer({
-    FIRECRAWL_API_KEY: 'fc-test',
-    FIRECRAWL_API_URL: backend.url,
-  });
-  t.after(() => stopChild(child));
-  const client = new StdioMcpClient(child);
-  await client.request('initialize', {
-    capabilities: {},
-    clientInfo: { name: 'firecrawl-total-output-cap', version: '0.0.0' },
-    protocolVersion: '2025-06-18',
-  });
-  client.notify('notifications/initialized');
+  const client = await startStdioClient(t, { FIRECRAWL_API_URL: backend.url }, 'firecrawl-total-output-cap');
 
   const result = await client.request('tools/call', {
     arguments: { query: 'many medium results' },
@@ -1328,18 +1257,7 @@ test('crawl bounding preserves the upstream continuation and small responses', a
   });
   t.after(() => backend.close());
 
-  const child = spawnServer({
-    FIRECRAWL_API_KEY: 'fc-test',
-    FIRECRAWL_API_URL: backend.url,
-  });
-  t.after(() => stopChild(child));
-  const client = new StdioMcpClient(child);
-  await client.request('initialize', {
-    capabilities: {},
-    clientInfo: { name: 'firecrawl-crawl-bounds', version: '0.0.0' },
-    protocolVersion: '2025-06-18',
-  });
-  client.notify('notifications/initialized');
+  const client = await startStdioClient(t, { FIRECRAWL_API_URL: backend.url }, 'firecrawl-crawl-bounds');
 
   const firstResult = await client.request('tools/call', {
     arguments: { id: 'job-1' },
@@ -1416,18 +1334,7 @@ test('crawl continuation pages are bounded and resumable mid-page', async (t) =>
   });
   t.after(() => backend.close());
 
-  const child = spawnServer({
-    FIRECRAWL_API_KEY: 'fc-test',
-    FIRECRAWL_API_URL: backend.url,
-  });
-  t.after(() => stopChild(child));
-  const client = new StdioMcpClient(child);
-  await client.request('initialize', {
-    capabilities: {},
-    clientInfo: { name: 'firecrawl-crawl-page-bounds', version: '0.0.0' },
-    protocolVersion: '2025-06-18',
-  });
-  client.notify('notifications/initialized');
+  const client = await startStdioClient(t, { FIRECRAWL_API_URL: backend.url }, 'firecrawl-crawl-page-bounds');
 
   const firstResult = await client.request('tools/call', {
     arguments: { id: 'job-big', next },
@@ -1478,18 +1385,7 @@ test('crawl bounding synthesizes a resumable cursor for a single upstream page',
   });
   t.after(() => backend.close());
 
-  const child = spawnServer({
-    FIRECRAWL_API_KEY: 'fc-test',
-    FIRECRAWL_API_URL: backend.url,
-  });
-  t.after(() => stopChild(child));
-  const client = new StdioMcpClient(child);
-  await client.request('initialize', {
-    capabilities: {},
-    clientInfo: { name: 'firecrawl-crawl-offset', version: '0.0.0' },
-    protocolVersion: '2025-06-18',
-  });
-  client.notify('notifications/initialized');
+  const client = await startStdioClient(t, { FIRECRAWL_API_URL: backend.url }, 'firecrawl-crawl-offset');
 
   const tools = await client.request('tools/list');
   const statusTool = tools.tools.find(
@@ -1542,18 +1438,7 @@ test('crawl continuation accepts a path-prefixed API base', async (t) => {
   });
   t.after(() => backend.close());
 
-  const child = spawnServer({
-    FIRECRAWL_API_KEY: 'fc-test',
-    FIRECRAWL_API_URL: `${backend.url}/firecrawl`,
-  });
-  t.after(() => stopChild(child));
-  const client = new StdioMcpClient(child);
-  await client.request('initialize', {
-    capabilities: {},
-    clientInfo: { name: 'firecrawl-prefixed-continuation', version: '0.0.0' },
-    protocolVersion: '2025-06-18',
-  });
-  client.notify('notifications/initialized');
+  const client = await startStdioClient(t, { FIRECRAWL_API_URL: `${backend.url}/firecrawl` }, 'firecrawl-prefixed-continuation');
 
   const result = await client.request('tools/call', {
     arguments: { id: 'job-prefix', next },

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -971,9 +971,20 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
     byName.get('firecrawl_research_search_papers').description,
     /indexed corpus.*biomedical.*PubMed.*bioRxiv.*medRxiv.*arXiv/is
   );
-  // The two surfaces that both answer to "research" must stay distinguishable.
-  // This has to live in the tool description, not a parameter `.describe()`:
-  // no property description survives serialization into tools/list.
+  // Property metadata must survive FastMCP/xsschema serialization. Keep this
+  // boundary visible in both the tool-level routing copy and parameter schema.
+  assert.match(
+    byName.get('firecrawl_search').inputSchema.properties.categories.description,
+    /research-affiliated websites.*separate from.*firecrawl_research_/is
+  );
+  assert.equal(
+    byName.get('firecrawl_search').inputSchema.additionalProperties,
+    false
+  );
+  assert.doesNotMatch(
+    JSON.stringify(tools.tools.map((tool) => tool.inputSchema)),
+    /"anyOf"/
+  );
   assert.match(
     byName.get('firecrawl_search').description,
     /categories: \["research"\].*research-affiliated websites.*`firecrawl_research_\*` tools are a separate surface.*PubMed, bioRxiv, medRxiv.*arXiv/is

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -1495,6 +1495,13 @@ test('local keyless stdio lists exactly its callable tools', async (t) => {
   });
   assert.equal(hiddenMap.isError, true);
   assert.equal(hiddenMap.structuredContent.code, 'AUTH_REQUIRED');
+  // Upstream-rejection guidance must give the agent a same-session fallback,
+  // not only operator setup steps: a spurious per-operation 401 otherwise
+  // makes agents abandon tasks that another Firecrawl tool could finish.
+  assert.match(
+    hiddenMap.structuredContent.message,
+    /other Firecrawl tools succeed.*retry once.*firecrawl_scrape/is
+  );
 });
 
 test('monitor create gives queries precedence over page targets', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -514,7 +514,7 @@ test('empty and likely-blocked results carry in-band Firecrawl notices', async (
         data: {
           markdown: '',
           metadata: { statusCode: 403 },
-          warning: `blocked ${'x'.repeat(20_000)}`,
+          warning: `blocked ${'x'.repeat(70_000)}`,
         },
       },
     },
@@ -535,11 +535,7 @@ test('empty and likely-blocked results carry in-band Firecrawl notices', async (
   await waitForHealth(port, child);
 
   for (const [name, arguments_, expectedCode] of [
-    [
-      'firecrawl_scrape',
-      { url: 'https://example.com/', response_format: 'concise' },
-      'LIKELY_BLOCKED',
-    ],
+    ['firecrawl_scrape', { url: 'https://example.com/' }, 'LIKELY_BLOCKED'],
     ['firecrawl_search', { query: 'no matching result' }, 'EMPTY_RESULT'],
   ]) {
     const response = await httpToolCall(port, {
@@ -945,7 +941,7 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   const describedProperties = properties.filter(
     (property) => property.description?.trim().length > 0
   );
-  assert.ok(properties.length >= 160, `expected full schema, got ${properties.length} properties`);
+  assert.ok(properties.length >= 150, `expected full schema, got ${properties.length} properties`);
   assert.ok(
     describedProperties.length / properties.length >= 0.95,
     `parameter-description coverage ${describedProperties.length}/${properties.length}`
@@ -1108,56 +1104,22 @@ test('payload-heavy responses are bounded with explicit retrieval guidance', asy
   });
   client.notify('notifications/initialized');
 
-  const tools = await client.request('tools/list');
-  for (const name of [
-    'firecrawl_scrape',
-    'firecrawl_search',
-    'firecrawl_crawl',
-    'firecrawl_check_crawl_status',
-    'firecrawl_parse',
-    'firecrawl_agent_status',
-    'firecrawl_interact',
-  ]) {
-    const tool = tools.tools.find((candidate) => candidate.name === name);
-    assert.ok(tool, `${name} must be listed`);
-    assert.deepEqual(tool.inputSchema.properties.response_format.enum, [
-      'concise',
-      'detailed',
-    ]);
-    assert.equal(tool.inputSchema.properties.response_format.default, 'detailed');
-  }
-
-  const detailedResult = await client.request('tools/call', {
+  const result = await client.request('tools/call', {
     arguments: { query: 'large result' },
     name: 'firecrawl_search',
   });
-  const detailedText = detailedResult.content[0].text;
-  const detailed = JSON.parse(detailedText);
-  assert.ok(detailedText.length <= 65_000, `detailed response was ${detailedText.length} chars`);
-  assert.equal(detailed._firecrawl.truncated, true);
-  assert.match(detailed._firecrawl.message, /narrower query|lower limit/i);
-
-  const conciseResult = await client.request('tools/call', {
-    arguments: { query: 'large result', response_format: 'concise' },
-    name: 'firecrawl_search',
-  });
-  const conciseText = conciseResult.content[0].text;
-  const concise = JSON.parse(conciseText);
-  assert.ok(conciseText.length <= 13_000, `concise response was ${conciseText.length} chars`);
-  assert.ok(conciseText.length < detailedText.length);
-  assert.equal(concise._firecrawl.truncated, true);
-  assert.match(concise._firecrawl.message, /response_format.*detailed/i);
-  assert.equal(concise.data.web[0].rawHtml, undefined);
-  assert.equal(concise.data.web[0].screenshot, undefined);
-  const titlePrefix = concise.data.web[0].title.split('\n[truncated')[0];
+  const text = result.content[0].text;
+  const payload = JSON.parse(text);
+  assert.ok(text.length <= 65_000, `bounded response was ${text.length} chars`);
+  assert.equal(payload._firecrawl.truncated, true);
+  assert.match(payload._firecrawl.message, /narrower query|lower limit/i);
+  const titlePrefix = payload.data.web[0].title.split('\n[truncated')[0];
   assert.equal(titlePrefix.endsWith('\ud83d'), false);
 
   const requests = backend.requests.filter(
     (request) => request.method === 'POST' && request.url === '/v2/search'
   );
-  assert.equal(requests.length, 2);
-  assert.equal(requests[0].body.response_format, undefined);
-  assert.equal(requests[1].body.response_format, undefined);
+  assert.equal(requests.length, 1);
 });
 
 test('many medium search results respect the total response cap', async (t) => {

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -281,7 +281,11 @@ async function startFakeFirecrawlBackend(options = {}) {
     introspectionMetadata = {},
     keylessEligible = false,
     crawlResponses = {},
+    crawlStartResponse,
+    feedbackResponse,
     keylessEligibilityResponse,
+    monitorResponse,
+    scrapeResponse,
     searchResponse,
   } = options;
   const requests = [];
@@ -361,6 +365,30 @@ async function startFakeFirecrawlBackend(options = {}) {
       return;
     }
 
+    if (req.method === 'POST' && req.url === '/v2/scrape' && scrapeResponse) {
+      res.writeHead(scrapeResponse.status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(scrapeResponse.body));
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/v2/crawl' && crawlStartResponse) {
+      res.writeHead(crawlStartResponse.status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(crawlStartResponse.body));
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/v2/feedback' && feedbackResponse) {
+      res.writeHead(feedbackResponse.status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(feedbackResponse.body));
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/v2/monitor' && monitorResponse) {
+      res.writeHead(monitorResponse.status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(monitorResponse.body));
+      return;
+    }
+
     if (req.method === 'GET' && crawlResponses[req.url]) {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify(crawlResponses[req.url]));
@@ -434,6 +462,136 @@ async function httpToolCall(port, { endpoint = '/v2/mcp', id, headers, params })
     method: 'POST',
   });
 }
+
+test('tool failures carry structured codes instead of silent success', async (t) => {
+  const backend = await startFakeFirecrawlBackend({
+    crawlStartResponse: { status: 200, body: { success: false, error: 'crawl rejected' } },
+    feedbackResponse: { status: 422, body: { error: 'feedback rejected', feedbackErrorCode: 'invalid_job' } },
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  for (const [name, arguments_, expectedCode] of [
+    ['firecrawl_crawl', { url: 'https://example.com/' }, 'CRAWL_START_FAILED'],
+    [
+      'firecrawl_feedback',
+      { endpoint: 'scrape', jobId: '00000000-0000-4000-8000-000000000000', rating: 'bad' },
+      'FEEDBACK_REJECTED',
+    ],
+    ['firecrawl_check_crawl_status', { id: 'bogus-job' }, 'UPSTREAM_REQUEST_FAILED'],
+    [
+      'firecrawl_search',
+      { query: 'firecrawl', includeDomains: ['example.com'], excludeDomains: ['example.com'] },
+      'INVALID_REQUEST',
+    ],
+  ]) {
+    const response = await httpToolCall(port, {
+      id: `structured-${name}`,
+      headers: { 'x-api-key': 'fc-test' },
+      params: { arguments: arguments_, name },
+    });
+    const result = parseSseJson(await response.text()).result;
+    assert.equal(result.isError, true, name);
+    assert.equal(result.structuredContent.code, expectedCode, name);
+    assert.equal(result.content[0].text, result.structuredContent.message, name);
+    assert.match(result.structuredContent.message, /retry|check|verify|use/i, name);
+    assert.equal(typeof result.structuredContent.original_error, 'string', name);
+  }
+});
+
+test('parse, interact, and monitor failures use the shared structured boundary', async (t) => {
+  const backend = await startFakeFirecrawlBackend({
+    monitorResponse: { status: 503, body: { success: false, error: 'monitor unavailable' } },
+    scrapeResponse: { status: 200, body: { success: true, data: { markdown: '# page' } } },
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  for (const [name, arguments_, expectedCode] of [
+    [
+      'firecrawl_interact',
+      { url: 'https://example.com/', prompt: 'read the title' },
+      'INTERACT_SESSION_UNAVAILABLE',
+    ],
+    [
+      'firecrawl_monitor_create',
+      { page: 'https://example.com/', goal: 'Track title changes' },
+      'UPSTREAM_REQUEST_FAILED',
+    ],
+  ]) {
+    const response = await httpToolCall(port, {
+      id: `structured-${name}`,
+      headers: { 'x-api-key': 'fc-test' },
+      params: { arguments: arguments_, name },
+    });
+    const result = parseSseJson(await response.text()).result;
+    assert.equal(result.isError, true, name);
+    assert.equal(result.structuredContent.code, expectedCode, name);
+    assert.equal(typeof result.structuredContent.original_error, 'string', name);
+  }
+});
+
+test('empty and likely-blocked results carry in-band Firecrawl notices', async (t) => {
+  const backend = await startFakeFirecrawlBackend({
+    scrapeResponse: {
+      status: 200,
+      body: { success: true, data: { markdown: '', metadata: { statusCode: 403 } } },
+    },
+    searchResponse: { status: 200, body: { success: true, data: { web: [] } } },
+  });
+  t.after(() => backend.close());
+  const port = await getFreePort();
+  const child = spawnServer({
+    CLOUD_SERVICE: 'true',
+    FASTMCP_ENDPOINT: '/v2/mcp',
+    FIRECRAWL_API_URL: backend.url,
+    FIRECRAWL_OAUTH_ISSUER: backend.url,
+    FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+    HTTP_STREAMABLE_SERVER: 'true',
+    PORT: String(port),
+  });
+  t.after(() => stopChild(child));
+  await waitForHealth(port, child);
+
+  for (const [name, arguments_, expectedCode] of [
+    ['firecrawl_scrape', { url: 'https://example.com/' }, 'LIKELY_BLOCKED'],
+    ['firecrawl_search', { query: 'no matching result' }, 'EMPTY_RESULT'],
+  ]) {
+    const response = await httpToolCall(port, {
+      id: `empty-${name}`,
+      headers: { 'x-api-key': 'fc-test' },
+      params: { arguments: arguments_, name },
+    });
+    const result = parseSseJson(await response.text()).result;
+    assert.notEqual(result.isError, true, name);
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload._firecrawl.code, expectedCode, name);
+    assert.match(payload._firecrawl.message, /empty|blocked/i, name);
+    assert.ok(Array.isArray(payload._firecrawl.next_actions), name);
+  }
+});
 
 test('HTTP cloud keyless transport preserves app challenge without advertising OAuth', async (t) => {
   const backend = await startFakeFirecrawlBackend();
@@ -696,6 +854,30 @@ class StdioMcpClient {
     this.#child.stdin.write(`${JSON.stringify(message)}\n`);
   }
 }
+
+test('local parse missing files return FILE_NOT_FOUND recovery', async (t) => {
+  const backend = await startFakeFirecrawlBackend();
+  t.after(() => backend.close());
+  const child = spawnServer({
+    FIRECRAWL_API_KEY: 'fc-test',
+    FIRECRAWL_API_URL: backend.url,
+  });
+  t.after(() => stopChild(child));
+  const client = new StdioMcpClient(child);
+  await client.request('initialize', {
+    capabilities: {},
+    clientInfo: { name: 'firecrawl-mcp-smoke', version: '0.0.0' },
+    protocolVersion: '2025-06-18',
+  });
+  client.notify('notifications/initialized');
+  const result = await client.request('tools/call', {
+    arguments: { filePath: '/definitely/missing/firecrawl-cycle2.pdf' },
+    name: 'firecrawl_parse',
+  });
+  assert.equal(result.isError, true);
+  assert.equal(result.structuredContent.code, 'FILE_NOT_FOUND');
+  assert.match(result.structuredContent.message, /check.*filePath/i);
+});
 
 test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   const child = spawnServer({

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -923,6 +923,37 @@ test('stdio transport initializes and lists Firecrawl tools', async (t) => {
   );
 
   const byName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+  const properties = tools.tools.flatMap((tool) =>
+    Object.values(tool.inputSchema.properties ?? {})
+  );
+  const describedProperties = properties.filter(
+    (property) => property.description?.trim().length > 0
+  );
+  assert.ok(properties.length >= 160, `expected full schema, got ${properties.length} properties`);
+  assert.ok(
+    describedProperties.length / properties.length >= 0.95,
+    `parameter-description coverage ${describedProperties.length}/${properties.length}`
+  );
+  assert.match(
+    byName.get('firecrawl_search').inputSchema.properties.scrapeOptions.description,
+    /each result.*response size.*credit use/is
+  );
+  assert.match(
+    byName.get('firecrawl_monitor_create').inputSchema.properties.body.description,
+    /advanced monitor request body.*replaces the simple-form fields/is
+  );
+  assert.match(
+    byName.get('firecrawl_parse').inputSchema.properties.filePath.description,
+    /local file to parse/is
+  );
+  assert.match(
+    byName.get('firecrawl_agent').inputSchema.properties.schema.description,
+    /final structured result.*reduce result size/is
+  );
+  assert.match(
+    byName.get('firecrawl_interact').inputSchema.properties.code.description,
+    /executable browser-session code/is
+  );
   assert.match(init.instructions, /firecrawl_scrape retrieves one supplied page/i);
   assert.match(init.instructions, /firecrawl_map enumerates URLs under a site/i);
   assert.match(

--- a/tests/mcp-smoke.test.mjs
+++ b/tests/mcp-smoke.test.mjs
@@ -464,6 +464,73 @@ test('tool failures carry structured codes instead of silent success', async (t)
   }
 });
 
+test('SDK status and code classify rate limits and opaque timeouts', async (t) => {
+  for (const testCase of [
+    {
+      name: 'firecrawl_search',
+      arguments: { query: 'rate-limited search' },
+      backend: {
+        searchResponse: {
+          status: 429,
+          body: {
+            success: false,
+            error:
+              'Rate limit exceeded. Consumed (req/min): 5, Remaining (req/min): 0. Upgrade your plan at https://firecrawl.dev/pricing for increased rate limits or please retry after 42s, resets at 2030-01-01T00:00:00.000Z',
+          },
+        },
+      },
+      expectedCode: 'RATE_LIMITED',
+      expectedRetryable: true,
+      expectedMessage: /42/,
+    },
+    {
+      name: 'firecrawl_scrape',
+      arguments: { url: 'https://example.com/' },
+      backend: {
+        scrapeResponse: {
+          status: 408,
+          body: { success: false, code: 'SCRAPE_TIMEOUT', error: 'heartbeat_failed' },
+        },
+      },
+      expectedCode: 'UPSTREAM_TIMEOUT',
+      expectedRetryable: true,
+    },
+  ]) {
+    await t.test(testCase.name, async (t) => {
+      const backend = await startFakeFirecrawlBackend(testCase.backend);
+      t.after(() => backend.close());
+      const port = await getFreePort();
+      const child = spawnServer({
+        CLOUD_SERVICE: 'true',
+        FASTMCP_ENDPOINT: '/v2/mcp',
+        FIRECRAWL_API_URL: backend.url,
+        FIRECRAWL_OAUTH_ISSUER: backend.url,
+        FIRECRAWL_OAUTH_INTROSPECT_SECRET: 'test-secret',
+        HTTP_STREAMABLE_SERVER: 'true',
+        PORT: String(port),
+      });
+      t.after(() => stopChild(child));
+      await waitForHealth(port, child);
+
+      const response = await httpToolCall(port, {
+        id: `sdk-error-${testCase.name}`,
+        headers: { 'x-api-key': 'fc-test' },
+        params: { arguments: testCase.arguments, name: testCase.name },
+      });
+      const result = parseSseJson(await response.text()).result;
+      assert.equal(result.isError, true);
+      assert.equal(result.structuredContent.code, testCase.expectedCode);
+      assert.equal(
+        result.structuredContent.retryable,
+        testCase.expectedRetryable
+      );
+      if (testCase.expectedMessage) {
+        assert.match(result.structuredContent.message, testCase.expectedMessage);
+      }
+    });
+  }
+});
+
 test('threat-protection policy blocks are permanent, not retryable', async (t) => {
   // apps/api emits a second domain-policy 403 besides the blocklist message:
   // "blocked by your organization's threat protection policy". It is just as
@@ -1369,7 +1436,7 @@ test('crawl continuation pages are bounded and resumable mid-page', async (t) =>
   assert.notEqual(second._firecrawl?.truncated, true);
 });
 
-test('crawl bounding exposes offset continuation for a single upstream page', async (t) => {
+test('crawl bounding synthesizes a resumable cursor for a single upstream page', async (t) => {
   const documents = Array.from({ length: 50 }, (_, index) => ({
     url: `https://example.com/${index + 1}`,
     markdown: `document ${index + 1}`,
@@ -1382,6 +1449,13 @@ test('crawl bounding exposes offset continuation for a single upstream page', as
         total: 50,
         next: null,
         data: documents,
+      },
+      '/v2/crawl/job-single-page?skip=25': {
+        status: 'completed',
+        completed: 50,
+        total: 50,
+        next: null,
+        data: documents.slice(25),
       },
     },
   });
@@ -1415,24 +1489,25 @@ test('crawl bounding exposes offset continuation for a single upstream page', as
   assert.equal(first.data[0].markdown, 'document 1');
   assert.equal(first.data[24].markdown, 'document 25');
   assert.equal(first._firecrawl.truncated, true);
-  assert.equal(first._firecrawl.next_offset, 25);
-  assert.match(first._firecrawl.message, /shown documents 1-25 of 50/i);
+  assert.equal(typeof first.next, 'string');
+  assert.match(first.next, /\/v2\/crawl\/job-single-page\?skip=25$/);
+  assert.equal(first._firecrawl.next, first.next);
+  assert.match(first._firecrawl.message, /shown documents 1-25.*50 total/i);
   assert.match(
     first._firecrawl.message,
-    /firecrawl_check_crawl_status.*id: "job-single-page".*offset: 25/i
+    /firecrawl_check_crawl_status.*id: "job-single-page".*next:/i
   );
 
   const secondResult = await client.request('tools/call', {
-    arguments: { id: 'job-single-page', offset: 25 },
+    arguments: { id: 'job-single-page', next: first.next },
     name: 'firecrawl_check_crawl_status',
   });
   const second = JSON.parse(secondResult.content[0].text);
   assert.equal(second.data.length, 25);
   assert.equal(second.data[0].markdown, 'document 26');
   assert.equal(second.data[24].markdown, 'document 50');
-  assert.equal(second._firecrawl.truncated, false);
-  assert.match(second._firecrawl.message, /shown documents 26-50 of 50/i);
-  assert.match(second._firecrawl.message, /all available documents have been returned/i);
+  assert.equal(second.next, null);
+  assert.notEqual(second._firecrawl?.truncated, true);
 });
 
 test('crawl continuation accepts a path-prefixed API base', async (t) => {


### PR DESCRIPTION
Agents hit three failure modes with this server: unbounded outputs that flood the context window, opaque errors that trigger pointless retries, and parameter descriptions that are silently dropped from `tools/list`. This PR fixes all three. Every change is validated by paired A/B evals against the base commit (results below).

### What changed

| Theme             | Change                                                                                                                                                                                      | Commits                       |
| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
| Bounded outputs   | Total output caps with compaction, in-band truncation notice, `offset` continuation for capped crawls (continuation pages bounded too)                                                      | `1b0eb40` `928222a` `8223468` `4bf7792` `366cb7b` |
| Structured errors | Stable `code` taxonomy + `retryable` flag + recovery guidance; `EMPTY_RESULT`/`LIKELY_BLOCKED` flags on silent-empty results; non-retryable `UNSUPPORTED_SITE` for domain-policy rejections; agent-actionable fallback in `AUTH_REQUIRED` recovery guidance; non-idempotent tools never advertise `retryable`; threat-protection blocks classified permanent | `a6d966b` `dcf19a8` `1f18740` `f98fe9c` `d77be3e` |
| Complete schemas  | Pin zod 4.1.13 (newer zod drops every `.describe()` in serialization — published npm packages ship **zero** param descriptions today); describe all 326 params on callable tools; cut description prose −48%  | `b8c22e2` `2ea6f6c` `11f8520` |
| Bugfix            | Local keyless `tools/list` advertised `firecrawl_parse`, which is not callable without a key; the advertised set now matches the callable set (Search + Scrape)                            | `8c1bf20`                     |

### Eval results

Paired A/B, 5 independent hosted runs: 300 traces, 150 pairs (2 models × 5
tasks × 3 reps × 5 runs). Baseline = this repo @ `678c92a`, packed identically
to the branch, so the diff isolates exactly these commits. The final run
covers the exact branch tip.

| Metric                                  | Baseline    | This PR             |
| --------------------------------------- | ----------- | ------------------- |
| Task success                            | 113/150 (75%) | 113/150 (75%)       |
| Paired win / tie / loss                 | —           | 4 / 142 / 4 *       |
| Duration, tokens, cost (paired medians) | —           | ≈ 0 (cost/tool-calls consistently equal or lower) |

\* Of the 8 non-ties, 5 traced to Firecrawl rate-limit/quota hits (3 favoring
this PR, 2 favoring baseline — environmental noise, roughly symmetric). The
other 3 are product-attributable and tell one story: an early revision's
`AUTH_REQUIRED` recovery text gave only operator guidance ("configure a key"),
so on a spurious per-operation 401 one model obediently gave up (2 losses in
run 4); after rewording the guidance to include a same-session fallback
(`1f18740`), that model recovered 6/6 in runs 5–6 and beat baseline's
improvised recovery once (1 win). The eval loop caught and corrected its own
regression.

Behavior deltas (from transcripts):

| Scenario                                          | Baseline                                                 | This PR                              |
| ------------------------------------------------- | -------------------------------------------------------- | ------------------------------------ |
| Permanently blocked URL (LinkedIn)                | Retried after rejection in 2/3 reps                      | 0/3 retries after `UNSUPPORTED_SITE` |
| Browser-interaction task, median tool calls       | 7                                                        | 3 (both models)                      |
| Error text relayed to agent                       | `Tool 'firecrawl_scrape' execution failed: <raw string>` | Clean message + `Recovery:` guidance |
| Scrape payload, bounding active (same call count) | 37.8 KB                                                  | 6.6 KB (−83%)                        |

Context-window cost of the schema changes:

|                                              | Baseline | This PR                                                                                               |
| -------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
| Tool description prose                       | 10.7 KB  | 5.6 KB (−48%)                                                                                         |
| `tools/list` total payload                   | 41.7 KB  | 53.2 KB (+~2.9k tokens, one-time, cache-friendly — the growth is param docs the zod bug was stripping) |
| Fresh tokens per task (median, final hosted run) | 16.5k    | 13.5k                                                                                      |

Local adversarial suite: 360 runs; adversarial-recovery scenarios 0/30 → 24/30.

Known service-side limitation: crawl-status pagination orders documents by
`finished_at, created_at` with no unique tie-break column, so skip-based
resume (which the `offset` continuation builds on) is not provably stable
when those timestamps tie. The continuation inherits that property; it cannot
be fixed client-side.

### Verification

85/85 tests, `tsc --noEmit` clean, eslint clean. Install verified from git and
tarball (builds via `prepare`, zod resolves 4.1.13 flat, 326/326 params on
callable tools described over stdio `tools/list`; only the deprecated
`firecrawl_extract` stub, which rejects immediately with redirect guidance,
leaves its unused params undescribed).

